### PR TITLE
Suggestion: Enable "Store to chest" but default to merge behavior

### DIFF
--- a/config/quark.cfg
+++ b/config/quark.cfg
@@ -668,7 +668,7 @@ management {
     B:"Press F in the inventory to switch item to main hand"=true
     B:"Press T in the inventory to link items to chat"=true
     B:"Right click add to shulker box"=true
-    B:"Store to chests"=false
+    B:"Store to chests"=true
 
     "store to chests" {
         # GUIs in which the drop off button should be forced to show up. Use the "Debug Classnames" option in chest buttons to find the names.
@@ -676,7 +676,7 @@ management {
          >
 
         # If true the default will be to merge your items into nearby chests, otherwise hold shift for this functionality.
-        B:"Invert button"=false
+        B:"Invert button"=true
         I:"Position X"=30
         I:"Position X (Creative)"=28
         I:"Position Y "=30


### PR DESCRIPTION
Enabling the "Merge to chest" button – the alternative version of the "Store to chest" button allows the player to auto cleanup their inventory to nearby chests.
Does not work with some TileEntities like crates from Immersive – but works with Vanilla, IronChest & actual additions.