### PR TITLE
It's unnecessary to remove and re-add all exu2 generators.(use NBTMatch flag)

### DIFF
--- a/scripts/ExtraUtilities2.zs
+++ b/scripts/ExtraUtilities2.zs
@@ -38,29 +38,9 @@ print("--- loading ExtraUtilities2.zs ---");
 	[[<ore:dustLunar>, <ore:dustLunar>, <ore:dustLunar>],
 	[<ore:dustLunar>, <ore:ingotUnstable>, <ore:dustLunar>], 
 	[<ore:dustLunar>, <ore:dustLunar>, <ore:dustLunar>]]);
-	
-# Removing and re-adding all generators
-	recipes.remove(<extrautils2:machine>);
-	recipes.addShaped("EnderGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_ender"}), [[<ore:enderpearl>, <ore:enderpearl>, <ore:enderpearl>],[<ore:enderpearl>, <ore:obsidian>, <ore:enderpearl>], [<ore:alloyBasic>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:alloyBasic>]]);
-	recipes.addShaped("SurvivalGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_survival"}), [[<ore:compressed1xCobblestone>, <ore:compressed1xCobblestone>, <ore:compressed1xCobblestone>],[<ore:compressed1xCobblestone>, <ore:ingotIron>, <ore:compressed1xCobblestone>], [<ore:dustRedstone>, <minecraft:furnace>, <ore:dustRedstone>]]);
-	recipes.addShaped("ExUEnchanter", <extrautils2:machine>.withTag({Type: "extrautils2:enchanter"}), [[null, <minecraft:enchanted_book>.anyDamage(), null],[<ore:gemDiamond>, <extrautils2:machine>, <ore:gemDiamond>], [<ore:ingotIron>, <minecraft:iron_ingot>, <ore:ingotIron>]]);
-	recipes.addShaped("ExUCrusher", <extrautils2:machine>.withTag({Type: "extrautils2:crusher"}), [[<ore:ingotIron>, <ore:craftingPiston>, <ore:ingotIron>],[<ore:ingotIron>, <extrautils2:machine>, <ore:ingotIron>], [<ore:ingotIron>, <minecraft:sticky_piston>, <ore:ingotIron>]]);
-	recipes.addShaped("ExUFurnace", <extrautils2:machine>.withTag({Type: "extrautils2:furnace"}), [[<ore:ingotBrick>, <ore:ingotBrick>, <ore:ingotBrick>],[<ore:ingotBrick>, <extrautils2:machine>, <ore:ingotBrick>], [<ore:ingotBrick>, <minecraft:brick>, <ore:ingotBrick>]]);
-	recipes.addShaped("SlimeGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_slime"}), [[<ore:slimeball>, <ore:slimeball>, <ore:slimeball>],[<ore:slimeball>, <ore:blockSlime>, <ore:slimeball>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("DisenchantmentGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_enchant"}), [[<ore:blockMagicalWood>, <ore:blockMagicalWood>, <ore:blockMagicalWood>],[<ore:blockMagicalWood>, <minecraft:enchanting_table>, <ore:blockMagicalWood>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("DeathGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_death"}), [[<minecraft:rotten_flesh>, <minecraft:rotten_flesh>, <minecraft:rotten_flesh>],[<minecraft:rotten_flesh>, <minecraft:spider_eye>, <minecraft:rotten_flesh>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("FrostyGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_ice"}), [[<minecraft:snowball>, <minecraft:snowball>, <minecraft:snowball>],[<minecraft:snowball>, <ore:ice>, <minecraft:snowball>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("HalitosisGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_dragonsbreath"}), [[<minecraft:purpur_block>, <minecraft:purpur_block>, <minecraft:purpur_block>],[<minecraft:purpur_block>, <minecraft:end_rod>, <minecraft:purpur_block>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("ExplosiveGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_tnt"}), [[<ore:gunpowder>, <ore:gunpowder>, <ore:gunpowder>],[<ore:gunpowder>, <minecraft:tnt>, <ore:gunpowder>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("OverclockedGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_overclock"}), [[<ore:dyeBlue>, <ore:dyeBlue>, <ore:dyeBlue>],[<ore:dyeBlue>, <ore:blockMetal>, <ore:dyeBlue>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("PinkGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_pink"}), [[<ore:dyePink>, <ore:dyePink>, <ore:dyePink>],[<ore:dyePink>, <minecraft:wool:6>, <ore:dyePink>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("PotionGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_potion"}), [[<ore:rodBlaze>, <ore:rodBlaze>, <ore:rodBlaze>],[<ore:rodBlaze>, <minecraft:brewing_stand>, <ore:rodBlaze>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("CulinaryGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_culinary"}), [[<ore:listAllveggie>, <ore:listAllveggie>, <ore:listAllveggie>],[<ore:listAllveggie>, <ore:listAllmeatcooked>, <ore:listAllveggie>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
-	recipes.addShaped("FurnaceGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), [[<ore:plateIron>, <ore:plateIron>, <ore:plateIron>],[<ore:plateIron>, <extrautils2:machine>, <ore:plateIron>], [<ore:dustRedstone>, <minecraft:furnace>, <ore:dustRedstone>]]);
-	recipes.addShaped("MagmaticGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_redstone"}), [[<ore:dustRedstone>, <ore:dustRedstone>, <ore:dustRedstone>],[<ore:dustRedstone>, <ore:blockRedstone>, <ore:dustRedstone>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator_lava"}), <ore:dustRedstone>]]);
-	recipes.addShaped("LavaGen", <extrautils2:machine>.withTag({Type: "extrautils2:generator_lava"}), [[<ore:plateGold>, <ore:plateGold>, <ore:plateGold>],[<ore:plateGold>, <minecraft:lava_bucket>, <ore:plateGold>], [<ore:dustRedstone>, <extrautils2:machine>.withTag({Type: "extrautils2:generator"}), <ore:dustRedstone>]]);
 
 # Nether Star Generator
+	recipes.remove(<extrautils2:machine>.withTag({Type: "extrautils2:generator_netherstar"}));
 	recipes.addShaped("Nether Star Generator", 
 	<extrautils2:machine>.withTag({Type: "extrautils2:generator_netherstar"}), 
 	[[<quark:black_ash>, <quark:black_ash>, <quark:black_ash>],
@@ -141,10 +121,7 @@ print("--- loading ExtraUtilities2.zs ---");
 	[<ore:plateSteel>, <ore:blockCoalCoke>, <ore:plateSteel>]]);
 
 # Machine Block
-	recipes.removeShaped(<extrautils2:machine>, 
-	[[<minecraft:iron_ingot>, <minecraft:redstone>, <minecraft:iron_ingot>],
-	[<minecraft:redstone>, <minecraft:chest>, <minecraft:redstone>], 
-	[<minecraft:iron_ingot>, <minecraft:redstone>, <minecraft:iron_ingot>]]);
+	recipes.remove(<extrautils2:machine>, true);
 	
 	var polishedStone = <extrautils2:decorativesolid:2>;
 # IC2

--- a/scripts/ExtraUtilities2.zs
+++ b/scripts/ExtraUtilities2.zs
@@ -40,7 +40,7 @@ print("--- loading ExtraUtilities2.zs ---");
 	[<ore:dustLunar>, <ore:dustLunar>, <ore:dustLunar>]]);
 
 # Nether Star Generator
-	recipes.remove(<extrautils2:machine>.withTag({Type: "extrautils2:generator_netherstar"}));
+	recipes.remove(<extrautils2:machine>.withTag({Type: "extrautils2:generator_netherstar"}),true);
 	recipes.addShaped("Nether Star Generator", 
 	<extrautils2:machine>.withTag({Type: "extrautils2:generator_netherstar"}), 
 	[[<quark:black_ash>, <quark:black_ash>, <quark:black_ash>],


### PR DESCRIPTION
use recipes.remove(output, NBTMatch);
set NBTMatch true can remove the recipe of machine block, not other machines.