### PR TITLE
Allow chiseling of IC2 Basalt

### DIFF
--- a/scripts/Chisel.zs
+++ b/scripts/Chisel.zs
@@ -4,6 +4,7 @@ print("--- loading Chisel.zs ---");
 
 	addVariation("basalt", <quark:basalt:1>);
 	addVariation("basalt", <quark:basalt>);
+        addVariation("basalt", <ic2:resource>);
 
 	addVariation("marble", <quark:marble>);
 


### PR DESCRIPTION
It seems you missed IC2 basalt, thanks for creating this pack by the way!
ic2:resource:0 specifically is basalt, I understand specifying :0 is not necessary?