### PR TITLE
Add thermal's steel block as valid in thermionic fabricator structure

### DIFF
--- a/config/modularmachinery/machinery/advanced_thermionic_fabricator.json
+++ b/config/modularmachinery/machinery/advanced_thermionic_fabricator.json
@@ -151,7 +151,8 @@
             "y": -1,
             "z": 0,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -167,7 +168,8 @@
             "y": 1,
             "z": 0,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -215,7 +217,8 @@
             "y": -1,
             "z": 0,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -255,7 +258,8 @@
             "y": 1,
             "z": 0,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -271,7 +275,8 @@
             "y": 1,
             "z": 4,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -367,7 +372,8 @@
             "y": 1,
             "z": 4,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -575,7 +581,8 @@
             "y": -1,
             "z": 4,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {
@@ -639,7 +646,8 @@
             "y": -1,
             "z": 4,
             "elements": [
-                "immersiveengineering:storage@8"
+                "immersiveengineering:storage@8",
+                "thermalfoundation:storage_alloy@0"
             ]
         },
         {


### PR DESCRIPTION
One of the current blocks required for the Advanced Thermionic Fabricator is Immersive Engineering's Block of Steel, which seems to only be obtainable with Chisel.

Here I added the Thermal Foundation Block of Steel as valid in addition to Immersive's Block of Steel, with the intention of not breaking current setups and simplifying future builds.
The steel block from thermal foundation is the only steel block that can be crafted with ingots.

Another idea I had is making the steel blocks required for the structure based on ore dictionary, but I could not figure that out.