### PR TITLE
Added planets to supported Astral dims

### DIFF
--- a/config/astralsorcery.cfg
+++ b/config/astralsorcery.cfg
@@ -197,19 +197,8 @@ general {
     # Whitelist of dimension ID's that will have special sky rendering [default: [0]]
     S:skySupportedDimensions <
         0
-     >
-
-    # Defines how much the 'sharpened' modifier increases the damage of the sword if applied. Config value is in percent. [range: 0.0 ~ 10000.0, default: 0.1]
-    S:swordSharpenedMultiplier=0.1
-
-    # IF a dimensionId is listed in 'skySupportedDimensions' you can add it here to keep its sky render, but AS will try to render only constellations on top of its existing sky render. [default: ]
-    S:weakSkyRenders <
-		-2
-		-1
-        1
-        7
-        99
-		100
+	-2
+        100
         101
         102
         103
@@ -233,7 +222,43 @@ general {
         121
         122
         123
-		144
+     >
+
+    # Defines how much the 'sharpened' modifier increases the damage of the sword if applied. Config value is in percent. [range: 0.0 ~ 10000.0, default: 0.1]
+    S:swordSharpenedMultiplier=0.1
+
+    # IF a dimensionId is listed in 'skySupportedDimensions' you can add it here to keep its sky render, but AS will try to render only constellations on top of its existing sky render. [default: ]
+    S:weakSkyRenders <
+	-2
+	-1
+        1
+        7
+        99
+	100
+        101
+        102
+        103
+        104
+        105
+        106
+        107
+        108
+        109
+        110
+        111
+        112
+        113
+        114
+        115
+        116
+        117
+        118
+        119
+        120
+        121
+        122
+        123
+	144
      >
 
     shooting_stars {


### PR DESCRIPTION
Checked on a test instance and yup, it works (as long as you also have them in weakSkyRenders).

Also holding off on adding Nether / End / Twilight / Compact Machines / whatever dim99 is because I hadn't tested those yet.

This commit closes #910.