### PR TITLE
Creative Builders Wand 'uncraftable'

### DIFF
--- a/scripts/Creative.zs
+++ b/scripts/Creative.zs
@@ -120,7 +120,7 @@ var twilightForestMasterTrophy = <simple_trophies:trophy>.withTag({
 # Creative Builder's Wand
 	mods.extendedcrafting.TableCrafting.addShaped(0, <extrautils2:itemcreativebuilderswand>, 
 	[[<extrautils2:itembuilderswand>, <cyclicmagic:cyclic_wand_build>.anyDamage(), <extrautils2:itembuilderswand>], 
-	[<betterbuilderswands:wanddiamond>.anyDamage(), <betterbuilderswands:wandunbreakable>.anyDamage(), <betterbuilderswands:wanddiamond>.anyDamage()], 
+	[<betterbuilderswands:wanddiamond>.anyDamage(), <betterbuilderswands:wandunbreakable:12>.anyDamage(), <betterbuilderswands:wanddiamond>.anyDamage()], 
 	[<extrautils2:itembuilderswand>, <cyclicmagic:cyclic_wand_build>.anyDamage(), <extrautils2:itembuilderswand>]]);  
 
 # Creative RFTools Screen


### PR DESCRIPTION
The Unbreakable Wand from Better Building Wands is crafted with meta 12. The one from the quest reward has Meta 0, which should probably be changed too