### PR TITLE
Loot Chest Rewards 3 to 1

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -5005,27 +5005,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5068,27 +5048,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         },
         "1:10": {
@@ -5151,27 +5111,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5227,27 +5167,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5305,27 +5225,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5381,27 +5281,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5469,27 +5349,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5557,27 +5417,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5645,27 +5485,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5733,27 +5553,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5821,27 +5621,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5905,27 +5685,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -5981,27 +5741,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6057,27 +5797,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6133,27 +5853,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6209,27 +5909,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6285,27 +5965,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6361,27 +6021,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6437,27 +6077,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6513,27 +6133,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6595,27 +6195,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6671,27 +6251,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6747,27 +6307,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6823,27 +6363,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6899,27 +6419,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -6976,27 +6476,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7039,27 +6519,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         },
         "1:10": {
@@ -7128,27 +6588,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7204,27 +6644,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7281,27 +6701,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7357,27 +6757,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7433,27 +6813,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7510,27 +6870,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7586,27 +6926,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7732,27 +7052,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7808,27 +7108,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7884,27 +7164,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -7960,27 +7220,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8036,27 +7276,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8112,27 +7332,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8188,27 +7388,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8270,27 +7450,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8346,27 +7506,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8500,27 +7640,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8610,27 +7730,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8686,27 +7786,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8762,27 +7842,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8841,27 +7901,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8920,27 +7960,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -8996,27 +8016,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9072,27 +8072,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9148,27 +8128,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9224,27 +8184,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9361,27 +8301,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9443,27 +8363,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9519,27 +8419,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9595,27 +8475,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9671,27 +8531,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9747,27 +8587,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9823,27 +8643,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9899,27 +8699,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -9975,27 +8755,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10052,27 +8812,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10186,27 +8926,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10262,27 +8982,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10338,27 +9038,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10414,27 +9094,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10490,27 +9150,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10578,27 +9218,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10660,27 +9280,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10739,27 +9339,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10815,27 +9395,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10891,27 +9451,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -10967,27 +9507,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11043,27 +9563,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11119,27 +9619,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11195,27 +9675,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11274,27 +9734,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11350,27 +9790,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11490,27 +9910,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11566,27 +9966,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11653,27 +10033,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11738,27 +10098,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11823,27 +10163,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11920,27 +10240,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -11996,27 +10296,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12072,27 +10352,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12151,27 +10411,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12230,27 +10470,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12309,27 +10529,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12385,27 +10585,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12542,27 +10722,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12618,27 +10778,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12695,27 +10835,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12774,27 +10894,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12873,27 +10973,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -12949,27 +11029,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13026,27 +11086,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13158,27 +11198,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13234,27 +11254,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13376,27 +11376,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13452,27 +11432,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13528,27 +11488,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13605,27 +11545,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13681,27 +11601,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13758,27 +11658,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13835,27 +11715,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13913,27 +11773,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -13992,27 +11832,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14071,27 +11891,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14147,27 +11947,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14226,27 +12006,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14302,27 +12062,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14381,27 +12121,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14545,27 +12265,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14621,27 +12321,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14697,27 +12377,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14774,27 +12434,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14853,27 +12493,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -14932,27 +12552,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15011,27 +12611,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15087,27 +12667,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15163,27 +12723,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15239,27 +12779,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15316,27 +12836,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15404,27 +12904,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15483,27 +12963,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15563,27 +13023,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15642,27 +13082,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15721,27 +13141,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15903,27 +13303,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -15979,27 +13359,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16055,27 +13415,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16131,27 +13471,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16207,27 +13527,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16289,27 +13589,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16365,27 +13645,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16542,27 +13802,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16646,27 +13886,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16750,27 +13970,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16854,27 +14054,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -16958,27 +14138,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17062,27 +14222,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17166,27 +14306,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17270,27 +14390,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17358,27 +14458,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17446,27 +14526,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17534,27 +14594,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17622,27 +14662,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17710,27 +14730,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17798,27 +14798,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -17902,27 +14882,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18006,27 +14966,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18110,27 +15050,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18214,27 +15134,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18325,27 +15225,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18427,27 +15307,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18529,27 +15389,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18631,27 +15471,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18707,27 +15527,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18783,27 +15583,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18886,27 +15666,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -18962,27 +15722,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19038,27 +15778,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19114,27 +15834,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19192,27 +15892,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19268,27 +15948,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19344,27 +16004,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19420,27 +16060,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19496,27 +16116,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19572,27 +16172,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19648,27 +16228,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19724,27 +16284,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19800,27 +16340,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19876,27 +16396,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -19952,27 +16452,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20028,27 +16508,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20180,27 +16640,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20256,27 +16696,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20332,27 +16752,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20408,27 +16808,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20490,27 +16870,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20566,27 +16926,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20642,27 +16982,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20721,27 +17041,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20797,27 +17097,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20877,27 +17157,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -20953,27 +17213,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21035,27 +17275,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21111,27 +17331,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21193,27 +17393,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21275,27 +17455,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21354,27 +17514,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21430,27 +17570,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21506,27 +17626,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21582,27 +17682,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21658,27 +17738,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21734,27 +17794,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21813,27 +17853,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21889,27 +17909,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -21965,27 +17965,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22041,27 +18021,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22120,27 +18080,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22196,27 +18136,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22272,27 +18192,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22348,27 +18248,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22424,27 +18304,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22542,27 +18402,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22618,27 +18458,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22694,27 +18514,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22811,27 +18611,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22887,27 +18667,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -22964,27 +18724,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23106,27 +18846,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23183,27 +18903,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23259,27 +18959,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23347,27 +19027,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23423,27 +19083,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23499,27 +19139,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23575,27 +19195,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23651,27 +19251,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23727,27 +19307,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23824,27 +19384,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -23992,27 +19532,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24071,27 +19591,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24147,27 +19647,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24223,27 +19703,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24308,27 +19768,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24384,27 +19824,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24460,27 +19880,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24536,27 +19936,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24618,27 +19998,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24703,27 +20063,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24779,27 +20119,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24855,27 +20175,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -24931,27 +20231,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25025,27 +20305,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25119,27 +20379,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25213,27 +20453,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25289,27 +20509,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25368,27 +20568,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25453,27 +20633,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25538,27 +20698,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25623,27 +20763,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25699,27 +20819,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25775,27 +20875,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25852,27 +20932,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -25934,27 +20994,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26010,27 +21050,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26086,27 +21106,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26226,27 +21226,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26308,27 +21288,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26390,27 +21350,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26466,27 +21406,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26548,27 +21468,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26624,27 +21524,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26700,27 +21580,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26776,27 +21636,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26852,27 +21692,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -26934,27 +21754,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27016,27 +21816,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27098,27 +21878,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27180,27 +21940,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27262,27 +22002,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27344,27 +22064,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27426,27 +22126,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27508,27 +22188,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27590,27 +22250,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27672,27 +22312,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27754,27 +22374,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27836,27 +22436,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -27918,27 +22498,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28000,27 +22560,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28082,27 +22622,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28158,27 +22678,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28234,27 +22734,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28313,27 +22793,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28390,27 +22850,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28600,27 +23040,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28677,27 +23097,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28771,27 +23171,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28854,27 +23234,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -28931,27 +23291,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29067,27 +23407,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29150,27 +23470,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29233,27 +23533,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29315,27 +23595,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29392,27 +23652,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29469,27 +23709,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29546,27 +23766,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29623,27 +23823,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29700,27 +23880,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29783,27 +23943,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29863,27 +24003,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -29943,27 +24063,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30032,27 +24132,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30109,27 +24189,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30186,27 +24246,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30263,27 +24303,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30352,27 +24372,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30435,27 +24435,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30512,27 +24492,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30589,27 +24549,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30666,27 +24606,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30749,27 +24669,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30832,27 +24732,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30915,27 +24795,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -30998,27 +24858,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31081,27 +24921,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31164,27 +24984,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31247,27 +25047,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31330,27 +25110,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31416,27 +25176,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31499,27 +25239,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31576,27 +25296,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31653,27 +25353,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31736,27 +25416,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31812,27 +25472,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -31960,27 +25600,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32042,27 +25662,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32121,27 +25721,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32201,27 +25781,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32283,27 +25843,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32364,27 +25904,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32444,27 +25964,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32524,27 +26024,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32604,27 +26084,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32691,27 +26151,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32767,27 +26207,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32849,27 +26269,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -32926,27 +26326,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33003,27 +26383,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33066,27 +26426,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33154,27 +26494,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33235,27 +26555,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33330,27 +26630,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33412,27 +26692,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33491,27 +26751,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33573,27 +26813,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33653,27 +26873,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33729,27 +26929,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33835,27 +27015,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -33941,27 +27101,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34059,27 +27199,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34165,27 +27285,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34243,27 +27343,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34349,27 +27429,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34467,27 +27527,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34573,27 +27613,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34649,27 +27669,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34725,27 +27725,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34820,27 +27800,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34921,27 +27881,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -34997,27 +27937,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35074,27 +27994,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35150,27 +28050,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35299,27 +28179,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35375,27 +28235,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35457,27 +28297,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35558,27 +28378,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35634,27 +28434,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35740,27 +28520,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35816,27 +28576,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -35892,27 +28632,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36014,27 +28734,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36090,27 +28790,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36166,27 +28846,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36242,27 +28902,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36318,27 +28958,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36394,27 +29014,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36470,27 +29070,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36546,27 +29126,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36622,27 +29182,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36698,27 +29238,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36774,27 +29294,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -36962,27 +29462,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37038,27 +29518,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37166,27 +29626,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37243,27 +29683,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37320,27 +29740,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37397,27 +29797,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37474,27 +29854,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37550,27 +29910,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37626,27 +29966,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37702,27 +30022,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37778,27 +30078,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37855,27 +30135,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -37932,27 +30192,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38009,27 +30249,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38086,27 +30306,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38163,27 +30363,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38239,27 +30419,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38315,27 +30475,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38391,27 +30531,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38467,27 +30587,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38544,27 +30644,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38621,27 +30701,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38698,27 +30758,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38775,27 +30815,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38852,27 +30872,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -38929,27 +30929,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39006,27 +30986,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39083,27 +31043,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39160,27 +31100,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39237,27 +31157,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39313,27 +31213,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39389,27 +31269,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39465,27 +31325,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39543,27 +31383,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39626,27 +31446,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39703,27 +31503,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39781,27 +31561,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39858,27 +31618,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -39935,27 +31675,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40012,27 +31732,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40089,27 +31789,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40166,27 +31846,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40243,27 +31903,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40320,27 +31960,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40397,27 +32017,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40474,27 +32074,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40551,27 +32131,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40628,27 +32188,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40705,27 +32245,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40782,27 +32302,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40859,27 +32359,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -40937,27 +32417,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41014,27 +32474,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41091,27 +32531,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41169,27 +32589,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41247,27 +32647,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41324,27 +32704,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41400,27 +32760,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41477,27 +32817,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41553,27 +32873,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41631,27 +32931,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41707,27 +32987,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41783,27 +33043,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41860,27 +33100,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -41936,27 +33156,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42012,27 +33212,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42088,27 +33268,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42164,27 +33324,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42241,27 +33381,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42323,27 +33443,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42411,27 +33511,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42490,27 +33570,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42566,27 +33626,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42654,27 +33694,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42742,27 +33762,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42824,27 +33824,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42912,27 +33892,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -42994,27 +33954,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43077,27 +34017,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43165,27 +34085,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43253,27 +34153,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43329,27 +34209,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43429,27 +34289,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43517,27 +34357,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43599,27 +34419,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43687,27 +34487,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43775,27 +34555,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43865,27 +34625,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -43947,27 +34687,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44029,27 +34749,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44111,27 +34811,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44193,27 +34873,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44275,27 +34935,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44357,27 +34997,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44439,27 +35059,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44521,27 +35121,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44603,27 +35183,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44679,27 +35239,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44877,27 +35417,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -44953,27 +35473,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45029,27 +35529,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45105,27 +35585,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45181,27 +35641,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45257,27 +35697,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45333,27 +35753,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45409,27 +35809,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45485,27 +35865,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45561,27 +35921,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45637,27 +35977,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45713,27 +36033,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45789,27 +36089,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45865,27 +36145,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -45941,27 +36201,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46017,27 +36257,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46093,27 +36313,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46169,27 +36369,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46245,27 +36425,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46321,27 +36481,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46397,27 +36537,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46473,27 +36593,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46550,27 +36650,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46627,27 +36707,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46703,27 +36763,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46779,27 +36819,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46855,27 +36875,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -46931,27 +36931,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47010,27 +36990,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47431,27 +37391,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47536,27 +37476,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47619,27 +37539,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47701,27 +37601,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47782,27 +37662,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47863,27 +37723,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -47944,27 +37784,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48025,27 +37845,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48106,27 +37906,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48182,27 +37962,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48267,27 +38027,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48343,27 +38083,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48428,27 +38148,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48504,27 +38204,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48589,27 +38269,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48665,27 +38325,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48750,27 +38390,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48826,27 +38446,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48911,27 +38511,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -48990,27 +38570,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49075,27 +38635,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49154,27 +38694,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49233,27 +38753,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49312,27 +38812,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49394,27 +38874,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49470,27 +38930,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49573,27 +39013,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49652,27 +39072,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49731,27 +39131,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49810,27 +39190,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49889,27 +39249,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -49968,27 +39308,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50154,27 +39474,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50251,27 +39551,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50336,27 +39616,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50424,27 +39684,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50521,27 +39761,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50618,27 +39838,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50703,27 +39903,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50788,27 +39968,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50873,27 +40033,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -50958,27 +40098,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51049,27 +40169,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51134,27 +40234,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51219,27 +40299,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51304,27 +40364,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51395,27 +40435,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51483,27 +40503,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51571,27 +40571,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51659,27 +40639,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51747,27 +40707,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51835,27 +40775,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -51926,27 +40846,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52011,27 +40911,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52096,27 +40976,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52181,27 +41041,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52266,27 +41106,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52351,27 +41171,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52436,27 +41236,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52521,27 +41301,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52609,27 +41369,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52694,27 +41434,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52779,27 +41499,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52864,27 +41564,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -52949,27 +41629,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53050,27 +41710,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53159,27 +41799,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53262,27 +41882,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53368,27 +41968,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53471,27 +42051,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53556,27 +42116,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53641,27 +42181,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53726,27 +42246,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53811,27 +42311,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -53917,27 +42397,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54023,27 +42483,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54123,27 +42563,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54214,27 +42634,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54290,27 +42690,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54366,27 +42746,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54442,27 +42802,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54518,27 +42858,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54594,27 +42914,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54675,27 +42975,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54763,27 +43043,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54840,27 +43100,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54922,27 +43162,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -54998,27 +43218,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55074,27 +43274,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55150,27 +43330,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55229,27 +43389,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55305,27 +43445,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55406,27 +43526,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55570,27 +43670,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55646,27 +43726,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55734,27 +43794,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55810,27 +43850,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55886,27 +43906,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -55962,27 +43962,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -56044,27 +44024,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -56120,27 +44080,7 @@
       },
       "rewards:9": {
         "0:10": {
-          "rewardID:8": "bq_standard:choice",
-          "index:3": 0,
-          "choices:9": {
-            "0:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "1:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            },
-            "2:10": {
-              "id:8": "bq_standard:loot_chest",
-              "Count:3": 1,
-              "OreDict:8": "",
-              "Damage:3": 101
-            }
+          "rewardID:8": "bq_standard:item", "index:3": 0, "rewards:9": {"0:10": {"id:8": "bq_standard:loot_chest","Count:3": 1,"OreDict:8": "","Damage:3": 101}
           }
         }
       }
@@ -60655,4 +48595,4 @@
       "home_offset_y:3": 0
     }
   }
-}
+ }


### PR DESCRIPTION
Quests now reward 1 Loot Chest instead of a choice of 3.
Because a choice of 3 random ones is silly, and this is long overdue