### PR TITLE
Disable Common Capabilities' IItemHandler feature

### DIFF
--- a/config/commoncapabilities.cfg
+++ b/config/commoncapabilities.cfg
@@ -8,7 +8,7 @@ capability {
     B:recipehandler=true
 
     # An item handler that is slot agnostic
-    B:slotlessitemhandler=true
+    B:slotlessitemhandler=false
 
     # Indicates if something has a temperature
     B:temperature=true


### PR DESCRIPTION
(Making this a draft since this should only be merged if there is no other way to fix this)

This should probably fix #1138 since Common Capabilities to my knowledge is the only mod interfering with the IItemHandler on TE satchels.