### PR TITLE
Update tileEntityMode to new config format.

### DIFF
--- a/config/rftools/rftools.cfg
+++ b/config/rftools/rftools.cfg
@@ -71,7 +71,7 @@ builder {
     I:spaceProjectorRFPerTick=1000
 
     # Can Tile Entities be moved? 'forbidden' means never, 'whitelist' means only whitelisted, 'blacklist' means all except blacklisted, 'allowed' means all (MOVE_FORBIDDEN,MOVE_WHITELIST,MOVE_BLACKLIST,MOVE_ALLOWED) [default: MOVE_WHITELIST]
-    S:tileEntityMode=whitelist
+    S:tileEntityMode=MOVE_WHITELIST
     D:voidShapeCardFactor=0.5
 }
 


### PR DESCRIPTION
RFTools seems to be expecting an integer now for tileEntityMode. Without it, it fails to parse the config (throws java.lang.NumberFormatException) and returns to default mod options, causing all sorts of chaos.