### PR TITLE
Disabled insertion of items into Dank Null through the Docking Station.

### DIFF
--- a/config/DankNull.cfg
+++ b/config/DankNull.cfg
@@ -26,7 +26,8 @@ general {
 
 "server rules" {
     # If true, you will be able to pipe items into the /dank/null Docking Station [default: true]
-    B:AllowDockInsertion=true
+    # Disabled Due to generating server lag due to memory leak if used as an general storage system Enable at your own risk
+    B:AllowDockInsertion=false
 
     # A semicolon separated list of items that are not allowed to be placed into the creative /dank/null
     # Format: modid:name:meta (meta optional: modid:name is acceptable) - Example: minecraft:diamond;minecraft:coal:1 [default: ]


### PR DESCRIPTION
Disabled insertion of items into Dank Null through the Docking Station as it cases quite a lot of memory leaks if used as a general storage as shown by the problems on the E2E-b server.

this change will make that a lot more unlikely while still allowing it to be used to quickly insert items into a general storage system for it to be sorted and made available to an AE2 system.