### PR TITLE
Update nuclearcraft.cfg

### DIFF
--- a/config/nuclearcraft.cfg
+++ b/config/nuclearcraft.cfg
@@ -1116,7 +1116,7 @@ processors {
      >
 
     # Conversion ratio between Redstone Flux and IC2 Energy Units.
-    I:rf_per_eu=16
+    I:rf_per_eu=4
 
     # If true, energy from GTCE can be accepted and emitted by NC machines.
     B:enable_gtce_eu=true


### PR DESCRIPTION
Put RF Per EU to a unified value. Infinite RF loop is possible otherwise, due to Mekanism conversion rates.