### PR TITLE
Recipes enhancements I come up with after enjoying this pack

### DIFF
--- a/scripts/ComputerCraft.zs
+++ b/scripts/ComputerCraft.zs
@@ -21,7 +21,6 @@ print("--- loading ComputerCraft.zs ---");
 	[<opencomputers:component>, <opencomputers:storage:2>, <opencomputers:component:6>], 
 	[null, <opencomputers:case1>, null]]);
 
-	
 # Advanced Computers
 	recipes.remove(<computercraft:computer:16384>);
 	recipes.addShapedMirrored("Advanced Computer", 
@@ -30,5 +29,12 @@ print("--- loading ComputerCraft.zs ---");
 	[<opencomputers:component:1>, <opencomputers:storage:3>, <opencomputers:component:8>], 
 	[null, <opencomputers:case2>, null]]);
 
-	
-		print("--- ComputerCraft.zs initialized ---");
+# Pocket Computer
+	recipes.remove(<computercraft:pocket_computer>);
+	mods.immersiveengineering.MetalPress.addRecipe(<computercraft:pocket_computer>, <computercraft:computer>, <immersiveengineering:mold:0>, 2000);
+
+# Advanced Pocket Computer
+	recipes.remove(<computercraft:pocket_computer:1>);
+	mods.immersiveengineering.MetalPress.addRecipe(<computercraft:pocket_computer:1>, <computercraft:computer:16384>, <immersiveengineering:mold:0>, 2000);
+
+print("--- ComputerCraft.zs initialized ---");

--- a/scripts/ImmersiveEngineering.zs
+++ b/scripts/ImmersiveEngineering.zs
@@ -6,6 +6,14 @@ print("--- loading ImmersiveEngineering.zs ---");
 # Removing Recycling recipes that produce IE Iron Nuggets
 	mods.immersiveengineering.ArcFurnace.removeRecipe(<immersiveengineering:metal:29>);
 
+
+# Sheetmetal Chute Smeltery compat
+	mods.tconstruct.Melting.addRecipe(<liquid:iron> * 72, <immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:chute_iron"}));
+	mods.tconstruct.Melting.addRecipe(<liquid:steel> * 72, <immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:chute_steel"}));
+	mods.tconstruct.Melting.addRecipe(<liquid:aluminum> * 72, <immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:chute_aluminum"}));
+	mods.tconstruct.Melting.addRecipe(<liquid:copper> * 72, <immersiveengineering:conveyor>.withTag({conveyorType: "immersiveengineering:chute_copper"}));
+
+
 # Crude Oil Unification
 	mods.immersivepetroleum.Distillation.addRecipe(
 	[<liquid:lubricant> * 9, <liquid:diesel> * 27,  <liquid:gasoline> * 39],

--- a/scripts/RandomThings.zs
+++ b/scripts/RandomThings.zs
@@ -36,8 +36,8 @@ for item in itemsToRemove {
 recipes.remove(<randomthings:enderbucket>);
 recipes.addShaped("ender_bucket1",
 	<randomthings:enderbucket>,
-	[[null, <minecraft:ender_pearl>, null],
-	[null, <minecraft:bucket>, null]]);
+	[[<minecraft:ender_pearl>],
+	[<minecraft:bucket>]]);
 recipes.addShaped("ender_bucket2",
 	<randomthings:enderbucket>,
 	[[<ore:plateIron>, <minecraft:ender_pearl>, <ore:plateIron>],

--- a/scripts/RandomThings.zs
+++ b/scripts/RandomThings.zs
@@ -31,6 +31,16 @@ print("--- loading RandomThings.zs ---");
 for item in itemsToRemove {
 	rh(item);
 }
+
+# Ender bucket recipe change
+recipes.remove(<randomthings:enderbucket>);
+recipes.addShaped("ender_bucket1",
+	<randomthings:enderbucket>,
+	[[null, <minecraft:ender_pearl>, null],
+	[null, <minecraft:bucket>, null]]);
+recipes.addShaped("ender_bucket2",
+	<randomthings:enderbucket>,
+	[[<ore:plateIron>, <minecraft:ender_pearl>, <ore:plateIron>],
+	[null, <ore:plateIron>, null]]);
+
 print("--- RandomThings.zs initialized ---");
-	
-	


### PR DESCRIPTION
### Ender Bucket from Random things
Default recipe takes two Iron Ingots and one Ender Pearl, this makes no sense compared to gated vanilla Bucket recipe. Now it requires either three Iron Plates or Bucket along with Ender Pearl
![New recipe](https://i.imgur.com/BY1dN53.png)
### Sheetmetal Chute smelting
Since it makes 6 Sheetmetal blocks for 12 Chutes, one chute smelts into 72mb of corresponding metal
![New recipe](https://i.imgur.com/tbFeqNJ.png)
### Pocket computers
CC:T Pocket computers can't do much compared to block variants, so there is no need to gate them, however, their default recipe still kinda silly compared to changed computer recipes. So I made the only logical thing to fix this:
![New recipe](https://i.imgur.com/UYbY4CC.png)