### PR TITLE
creating frog/foxhound mobcap and adding frog egg to market

### DIFF
--- a/config/FarmingForBlockheads/Market.json
+++ b/config/FarmingForBlockheads/Market.json
@@ -58,7 +58,8 @@
     "harvestcraft:taroseeditem": "1*minecraft:emerald",
     "harvestcraft:juniperberryseeditem": "1*minecraft:emerald",
     "harvestcraft:tomatilloseeditem": "1*minecraft:emerald",
-	  "minecraft:mooshroom_spawn_egg": "10*minecraft:emerald"
+	  "minecraft:mooshroom_spawn_egg": "10*minecraft:emerald",
+	"minecraft:spawn_egg@{EntityTag: {id: \"quark:frog\"}}": "10*minecraft:emerald"
   },
   "defaults amount": {
     "Vanilla Seeds": 1,

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -24,5 +24,15 @@
 			123
 		],
 		"result": "deny"
+	},
+	{
+    "mob": "quark:frog",
+    "mincount":"30",
+    "result": "deny"
+	},
+	{
+    "mob": "quark:foxhound",
+    "mincount":"30",
+    "result": "deny"
 	}
 ]


### PR DESCRIPTION
Added quark Frog and Foxhound mobcap using  InControl
and added a Frog spawn egg to the Farming For Blockheads market.
Cap currently set at 30 can be adjusted if needed.