### PR TITLE
Update nuclearcraft.cfg

### DIFF
--- a/config/nuclearcraft.cfg
+++ b/config/nuclearcraft.cfg
@@ -1420,7 +1420,7 @@ radiation {
     D:radiation_geiger_block_redstone=3.0
 
     # If enabled, radiation shielding attachment recipes will be added for all registered armor pieces.
-    B:radiation_shielding_default_recipes=true
+    B:radiation_shielding_default_recipes=false
 
     # List of armor item stacks for which shielding recipes will not be added by default. Format: 'modid:armorName:meta'.
     S:radiation_shielding_item_blacklist <


### PR DESCRIPTION
Changed  the following from true to false. NC radiation is not enabled by default and all of these shielding recipes shove the actual armor recipe 3-5 pages deep. NC shielding has already been removed from JEI at some point, i think this part was just overlooked.

 If enabled, radiation shielding attachment recipes will be added for all registered armor pieces.
    B:radiation_shielding_default_recipes=false