### PR TITLE
Fix integrated dynamics Generator, mechanical squeezer, and Mechanical drying basin recipes

### DIFF
--- a/scripts/IntegratedDynamics.zs
+++ b/scripts/IntegratedDynamics.zs
@@ -28,7 +28,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Generator", 
 	<integrateddynamics:coal_generator>, 
 	[[<integrateddynamics:crystalized_menril_chunk>, <ic2:te:46>, <integrateddynamics:crystalized_menril_chunk>],
-	[<integrateddynamics:crystalized_menril_block>, <integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:crystalized_menril_block>], 
+	[<integrateddynamics:crystalized_menril_block>, <integrateddynamics:energy_battery>.withTag({}), <integrateddynamics:crystalized_menril_block>], 
 	[<integrateddynamics:crystalized_menril_chunk>, <ic2:te:46>, <integrateddynamics:crystalized_menril_chunk>]]);
 
 # Mechanical Squeezer
@@ -36,7 +36,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Mechanical Squeezer", 
 	<integrateddynamics:mechanical_squeezer>, 
 	[[<ore:dustDiamond>, <integrateddynamics:squeezer>, <ore:dustDiamond>],
-	[<integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:squeezer>, <integrateddynamics:energy_battery>.withTag({energy: 0})], 
+	[<integrateddynamics:energy_battery>.withTag({}), <integrateddynamics:squeezer>, <integrateddynamics:energy_battery>.withTag({})], 
 	[<ore:plateObsidian>, <integrateddynamics:squeezer>, <ore:plateObsidian>]]);
 
 # Mechanical Drying Basin
@@ -44,7 +44,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Mechanical Drying Basin", 
 	<integrateddynamics:mechanical_drying_basin>, 
 	[[<ore:plateObsidian>, <integrateddynamics:drying_basin>, <ore:plateObsidian>],
-	[<integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:drying_basin>, <integrateddynamics:energy_battery>.withTag({energy: 0})], 
+	[<integrateddynamics:energy_battery>.withTag({}), <integrateddynamics:drying_basin>, <integrateddynamics:energy_battery>.withTag({})], 
 	[<ore:plateObsidian>, <integrateddynamics:drying_basin>, <ore:plateObsidian>]]);
 
 	

--- a/scripts/IntegratedDynamics.zs
+++ b/scripts/IntegratedDynamics.zs
@@ -28,7 +28,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Generator", 
 	<integrateddynamics:coal_generator>, 
 	[[<integrateddynamics:crystalized_menril_chunk>, <ic2:te:46>, <integrateddynamics:crystalized_menril_chunk>],
-	[<integrateddynamics:crystalized_menril_block>, <integrateddynamics:energy_battery>.anyDamage(), <integrateddynamics:crystalized_menril_block>], 
+	[<integrateddynamics:crystalized_menril_block>, <integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:crystalized_menril_block>], 
 	[<integrateddynamics:crystalized_menril_chunk>, <ic2:te:46>, <integrateddynamics:crystalized_menril_chunk>]]);
 
 # Mechanical Squeezer
@@ -36,7 +36,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Mechanical Squeezer", 
 	<integrateddynamics:mechanical_squeezer>, 
 	[[<ore:dustDiamond>, <integrateddynamics:squeezer>, <ore:dustDiamond>],
-	[<integrateddynamics:energy_battery>.anyDamage(), <integrateddynamics:squeezer>, <integrateddynamics:energy_battery>.anyDamage()], 
+	[<integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:squeezer>, <integrateddynamics:energy_battery>.withTag({energy: 0})], 
 	[<ore:plateObsidian>, <integrateddynamics:squeezer>, <ore:plateObsidian>]]);
 
 # Mechanical Drying Basin
@@ -44,7 +44,7 @@ print("--- loading IntegratedDynamics.zs ---");
 	recipes.addShapedMirrored("IntegratedDynamics Mechanical Drying Basin", 
 	<integrateddynamics:mechanical_drying_basin>, 
 	[[<ore:plateObsidian>, <integrateddynamics:drying_basin>, <ore:plateObsidian>],
-	[<integrateddynamics:energy_battery>.anyDamage(), <integrateddynamics:drying_basin>, <integrateddynamics:energy_battery>.anyDamage()], 
+	[<integrateddynamics:energy_battery>.withTag({energy: 0}), <integrateddynamics:drying_basin>, <integrateddynamics:energy_battery>.withTag({energy: 0})], 
 	[<ore:plateObsidian>, <integrateddynamics:drying_basin>, <ore:plateObsidian>]]);
 
 	


### PR DESCRIPTION
Changed recipe to use batteries with 0 energy. ID made a recent change where all batteries have the energy level NBT(on previous versions an empty battery had no nbt data) making it no longer possible to use .anyDamage()... i tried for quite some time to make it work with all energy levels. I also tried to make it work with both empty and full, but short of adding multiple recipes i could not find a way. Maybe you will have better luck but this will at least make these items craftable 💃