### PR TITLE
Update CraftTweaker scripts for latest Extreme Reactors

### DIFF
--- a/scripts/Avaritia.zs
+++ b/scripts/Avaritia.zs
@@ -83,7 +83,7 @@ print("--- loading Avaritia.zs ---");
 	[<ore:ingotCrystalMatrix>, <ore:ingotCosmicNeutronium>, <avaritia:cosmic_meatballs>, 
 	<avaritia:ultimate_stew>, <avaritia:endest_pearl>, <ore:record>, 
 	<draconicevolution:awakened_core>, <ore:blockDraconiumAwakened>, 
-	<ore:blockLudicrite>, <bigreactors:minerals:1>, <bigreactors:minerals>, 
+	<ore:blockLudicrite>, <bigreactors:mineralbenitoite>, <bigreactors:mineralanglesite>, 
 	<ore:dragonEgg>, <extendedcrafting:storage:7>, <ore:blockAethium>, 
 	<ore:plateElite>, <ore:blockTitaniumAluminide>, <ore:blockTitaniumIridium>, 
 	<ore:blockEvilMetal>, <ore:blockDemonicMetal>, <ore:blockMirion>, 

--- a/scripts/Creative.zs
+++ b/scripts/Creative.zs
@@ -15,8 +15,8 @@ print("--- loading Creative.zs ---");
 	var draconicEnergyCore = <draconicevolution:draconic_energy_core>;
 	var rtgFuel = <ic2:nuclear:10>;
 	var dilithium = <ore:gemDilithium>;
-	var anglesite = <bigreactors:minerals>;
-	var benitoite = <bigreactors:minerals:1>;
+	var anglesite = <bigreactors:mineralanglesite>;
+	var benitoite = <bigreactors:mineralbenitoite>;
 	var ingotMirion = <ore:ingotMirion>;
 	var manaTablet = <botania:manatablet>.withTag({mana: 500000});
 	var megaDrum = <extrautils2:drum:3>;
@@ -36,7 +36,7 @@ print("--- loading Creative.zs ---");
 	var speedUpgrade3 = <extrautils2:ingredients:16>;
 	var sunCrystal = <extrautils2:suncrystal>;
 	var kleinBottle = <extrautils2:klein>;
-	var blockLudicrite = <bigreactors:blockmetals:4>;
+	var blockLudicrite = <bigreactors:blockludicrite>;
 	var gasPad = <advancedrocketry:oxygencharger>;
     var blockOsgloglas = <ore:blockOsgloglas>;
 	var blockMirion = <ore:blockMirion>;
@@ -97,8 +97,8 @@ var twilightForestMasterTrophy = <simple_trophies:trophy>.withTag({
 	<astralsorcery:itemcraftingcomponent:1>,<botania:manaresource>,<botania:manaresource:4>,
 	<botania:manaresource:7>,<draconicevolution:draconium_ingot>,<draconicevolution:draconic_ingot>,
 	<extendedcrafting:material>,<extendedcrafting:material:24>,<extrautils2:ingredients:11>,<extrautils2:ingredients:12>,
-	<extrautils2:ingredients:17>,<bigreactors:ingotmetals:1>,<bigreactors:ingotmetals:3>,
-	<bigreactors:ingotmetals:4>,<immersiveengineering:material:19>,<immersiveengineering:metal:5>,
+	<extrautils2:ingredients:17>,<bigreactors:ingotcyanite>,<bigreactors:ingotblutonium>,
+	<bigreactors:ingotludicrite>,<immersiveengineering:material:19>,<immersiveengineering:metal:5>,
 	<mekanism:ingot>,<mekanism:ingot:1>,<mekanism:ingot:3>,<thermalfoundation:material:131>,
 	<thermalfoundation:material:132>,<thermalfoundation:material:133>,<thermalfoundation:material:134>,
 	<thermalfoundation:material:135>,<thermalfoundation:material:136>,<thermalfoundation:material:160>,
@@ -172,13 +172,13 @@ var twilightForestMasterTrophy = <simple_trophies:trophy>.withTag({
 # Mekanism Creative Tank
 	mods.extendedcrafting.TableCrafting.addShaped(4, <mekanism:machineblock2:11>.withTag({tier: 4, mekData:{}}), 
 	[[<industrialforegoing:black_hole_tank>, <forge:bucketfilled>.withTag({FluidName: "milk_goat", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "blood", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "liquiddna", Amount: 1000}), <thermalexpansion:tank>.withTag({Fluid: {FluidName: "bio.ethanol", Amount: 32000}}), <forge:bucketfilled>.withTag({FluidName: "juice", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "mutagen", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "biomass", Amount: 1000}), <industrialforegoing:black_hole_tank>], 
-	[<forge:bucketfilled>.withTag({FluidName: "empoweredoil", Amount: 1000}), resonantFrame, ingotUltimate, ingotUltimate, <bigreactors:minerals>, ingotUltimate, ingotUltimate, resonantFrame, <forge:bucketfilled>.withTag({FluidName: "witchwater", Amount: 1000})], 
+	[<forge:bucketfilled>.withTag({FluidName: "empoweredoil", Amount: 1000}), resonantFrame, ingotUltimate, ingotUltimate, <bigreactors:mineralanglesite>, ingotUltimate, ingotUltimate, resonantFrame, <forge:bucketfilled>.withTag({FluidName: "witchwater", Amount: 1000})], 
 	[<forge:bucketfilled>.withTag({FluidName: "xu_demonic_metal", Amount: 1000}), ingotUltimate, megaDrum, megaDrum, megaDrum, megaDrum, megaDrum, ingotUltimate, <forge:bucketfilled>.withTag({FluidName: "essence", Amount: 1000})], 
 	[<forge:bucketfilled>.withTag({FluidName: "draconium", Amount: 1000}), ingotUltimate, megaDrum, awakendedCore, ultCatalyst, awakendedCore, megaDrum, ingotUltimate, <forge:bucketfilled>.withTag({FluidName: "sewage", Amount: 1000})], 
-	[<thermalexpansion:tank>.withTag({Fluid: {FluidName: "tree_oil", Amount: 32000}}), <bigreactors:minerals>, megaDrum, ultCatalyst, <draconicevolution:chaotic_core>, ultCatalyst, megaDrum, <bigreactors:minerals>, <thermalexpansion:tank>.withTag({Fluid: {FluidName: "ic2uu_matter", Amount: 32000}})], 
+	[<thermalexpansion:tank>.withTag({Fluid: {FluidName: "tree_oil", Amount: 32000}}), <bigreactors:mineralanglesite>, megaDrum, ultCatalyst, <draconicevolution:chaotic_core>, ultCatalyst, megaDrum, <bigreactors:mineralanglesite>, <thermalexpansion:tank>.withTag({Fluid: {FluidName: "ic2uu_matter", Amount: 32000}})], 
 	[<forge:bucketfilled>.withTag({FluidName: "pyrotheum", Amount: 1000}), ingotUltimate, megaDrum, awakendedCore, ultCatalyst, awakendedCore, megaDrum, ingotUltimate, <forge:bucketfilled>.withTag({FluidName: "ic2pahoehoe_lava", Amount: 1000})], 
 	[<forge:bucketfilled>.withTag({FluidName: "aerotheum", Amount: 1000}), ingotUltimate, megaDrum, megaDrum, megaDrum, megaDrum, megaDrum, ingotUltimate, <forge:bucketfilled>.withTag({FluidName: "clay", Amount: 1000})], 
-	[<forge:bucketfilled>.withTag({FluidName: "essence", Amount: 1000}), resonantFrame, ingotUltimate, ingotUltimate, <bigreactors:minerals>, ingotUltimate, ingotUltimate, resonantFrame, <forge:bucketfilled>.withTag({FluidName: "tritium", Amount: 1000})], 
+	[<forge:bucketfilled>.withTag({FluidName: "essence", Amount: 1000}), resonantFrame, ingotUltimate, ingotUltimate, <bigreactors:mineralanglesite>, ingotUltimate, ingotUltimate, resonantFrame, <forge:bucketfilled>.withTag({FluidName: "tritium", Amount: 1000})], 
 	[<industrialforegoing:black_hole_tank>, <forge:bucketfilled>.withTag({FluidName: "ender", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "cryotheum", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "petrotheum", Amount: 1000}), <thermalexpansion:tank>.withTag({Fluid: {FluidName: "mana", Amount: 32000}}), <forge:bucketfilled>.withTag({FluidName: "refined_fuel", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "mirion", Amount: 1000}), <forge:bucketfilled>.withTag({FluidName: "neutron", Amount: 1000}), <industrialforegoing:black_hole_tank>]]); 
 	recipes.addShapeless("Creative Tank Reset", 
 	<mekanism:machineblock2:11>.withTag({tier: 4, mekData: {}}), 
@@ -186,15 +186,15 @@ var twilightForestMasterTrophy = <simple_trophies:trophy>.withTag({
 
 # Storage Drawers Unlimited Withdrawel Upgrade
 	mods.extendedcrafting.TableCrafting.addShaped(4, <storagedrawers:upgrade_creative:1> * 2, 
-	[[<ore:blockCrystalMatrix>, blackHoleUnit, ultCatalyst, ultCatalyst, <bigreactors:minerals>, ultCatalyst, ultCatalyst, blackHoleUnit, <ore:blockCrystalMatrix>], 
+	[[<ore:blockCrystalMatrix>, blackHoleUnit, ultCatalyst, ultCatalyst, <bigreactors:mineralanglesite>, ultCatalyst, ultCatalyst, blackHoleUnit, <ore:blockCrystalMatrix>], 
 	[blackHoleUnit, resonantFrame, resonantFrame, draconicChest, <extracells:storage.component:3>, draconicChest, resonantFrame, resonantFrame, blackHoleUnit], 
 	[ultCatalyst, resonantFrame, <ore:blockAethium>, <draconicevolution:chaotic_core>, benitoite, <draconicevolution:chaotic_core>, <ore:blockAethium>, resonantFrame, ultCatalyst], 
 	[ultCatalyst, draconicChest, creativeEssence, <rftools:powercell_creative>, <ore:ingotInfinity>, <ic2:te:86>, creativeEssence, draconicChest, ultCatalyst], 
-	[<bigreactors:minerals>, <extracells:storage.component:3>, benitoite, <environmentaltech:solar_cont_6>, twilightForestMasterTrophy, <environmentaltech:solar_cont_6>, benitoite, <extracells:storage.component:3>, <bigreactors:minerals>], 
+	[<bigreactors:mineralanglesite>, <extracells:storage.component:3>, benitoite, <environmentaltech:solar_cont_6>, twilightForestMasterTrophy, <environmentaltech:solar_cont_6>, benitoite, <extracells:storage.component:3>, <bigreactors:mineralanglesite>], 
 	[ultCatalyst, draconicChest, creativeEssence, creativeTank, <ore:ingotInfinity>, creativeGasTank, creativeEssence, draconicChest, ultCatalyst], 
 	[ultCatalyst, resonantFrame, <ore:blockAethium>, <draconicevolution:chaotic_core>, benitoite, <draconicevolution:chaotic_core>, <ore:blockAethium>, resonantFrame, ultCatalyst], 
 	[blackHoleUnit, resonantFrame, resonantFrame, draconicChest, <extracells:storage.component:3>, draconicChest, resonantFrame, resonantFrame, blackHoleUnit], 
-	[<ore:blockCrystalMatrix>, blackHoleUnit, ultCatalyst, ultCatalyst, <bigreactors:minerals>, ultCatalyst, ultCatalyst, blackHoleUnit, <ore:blockCrystalMatrix>]]);
+	[<ore:blockCrystalMatrix>, blackHoleUnit, ultCatalyst, ultCatalyst, <bigreactors:mineralanglesite>, ultCatalyst, ultCatalyst, blackHoleUnit, <ore:blockCrystalMatrix>]]);
 	
 	recipes.addShapeless("Creative Storage Upgrade Duplication", 
 	<storagedrawers:upgrade_creative:1> * 2, 
@@ -244,12 +244,12 @@ var twilightForestMasterTrophy = <simple_trophies:trophy>.withTag({
 	[[<psi:cad_assembly:4>, <psi:cad_assembly:4>, <ore:ingotIvoryPsi>, null, null, null, null, null, null], 
 	[<psi:cad_assembly:4>, <ore:blockInfinity>, <psi:cad_assembly:4>, <ore:ingotIvoryPsi>, null, null, null, null, null], 
 	[<ore:ingotIvoryPsi>, <psi:cad_assembly:4>, <psi:cad_colorizer_:16>, <psi:cad_assembly:4>, null, null, null, null, null], 
-	[null, <ore:ingotIvoryPsi>, <psi:cad_assembly:4>, <bigreactors:minerals:1>, <bigreactors:minerals:1>, null, null, null, null], 
-	[null, null, null, <bigreactors:minerals:1>, <psi:cad_assembly:3>, <psi:cad_assembly:3>, null, null, null], 
+	[null, <ore:ingotIvoryPsi>, <psi:cad_assembly:4>, <bigreactors:mineralbenitoite>, <bigreactors:mineralbenitoite>, null, null, null, null], 
+	[null, null, null, <bigreactors:mineralbenitoite>, <psi:cad_assembly:3>, <psi:cad_assembly:3>, null, null, null], 
 	[null, null, null, null, <psi:cad_assembly:3>, <psi:cad_assembly:3>, <psi:cad_assembly:3>, null, null], 
 	[null, null, null, null, null, <psi:cad_assembly:3>, <psi:cad_assembly:3>, <psi:cad_assembly:3>, null], 
-	[null, null, null, null, null, null, <psi:cad_assembly:3>, <psi:cad_assembly:3>, <bigreactors:minerals:1>], 
-	[null, null, null, null, null, null, null, <bigreactors:minerals:1>, <bigreactors:minerals:1>]]); 
+	[null, null, null, null, null, null, <psi:cad_assembly:3>, <psi:cad_assembly:3>, <bigreactors:mineralbenitoite>], 
+	[null, null, null, null, null, null, null, <bigreactors:mineralbenitoite>, <bigreactors:mineralbenitoite>]]); 
 
 # DE Creative Block Exchanger
 	mods.extendedcrafting.TableCrafting.addShaped(4, <draconicevolution:creative_exchanger>,

--- a/scripts/ExtendedCrafting.zs
+++ b/scripts/ExtendedCrafting.zs
@@ -45,7 +45,7 @@ print("--- loading ExtendedCrafting.zs ---");
 	
 	mods.thermalexpansion.InductionSmelter.addRecipe
 	(<extendedcrafting:material> * 3, 
-	<thermalfoundation:storage_alloy:2>, <bigreactors:blockmetals:2>, 15000);	
+	<thermalfoundation:storage_alloy:2>, <bigreactors:blockgraphite>, 15000);	
 	
 # Crafting Core
 	recipes.remove(<extendedcrafting:crafting_core>);

--- a/scripts/ExtremeReactors.zs
+++ b/scripts/ExtremeReactors.zs
@@ -6,7 +6,7 @@ print("--- loading ExtremeReactors.zs ---");
 # *======= Recipes =======*
 
 # Cyanite in NuclearCraft Fission Reactor
-	mods.nuclearcraft.fission.addRecipe([<immersiveengineering:metal:5>, <bigreactors:ingotmetals:1>, 4800.0, 100.0, 40.0, "URANIUM"]);
+	mods.nuclearcraft.fission.addRecipe([<immersiveengineering:metal:5>, <bigreactors:ingotcyanite>, 4800.0, 100.0, 40.0, "URANIUM"]);
 
 # Reactor Controller
 	recipes.remove(<bigreactors:reactorcontroller>);
@@ -73,43 +73,43 @@ print("--- loading ExtremeReactors.zs ---");
 	[<bigreactors:turbinehousing>, <ic2:crafting:36>, <bigreactors:turbinehousing>]]);
 
 # Blutonium Block
-	recipes.remove(<bigreactors:blockmetals:3>);
+	recipes.remove(<bigreactors:blockblutonium>);
 	recipes.addShapedMirrored("Blutonium Block", 
-	<bigreactors:blockmetals:3>, 
+	<bigreactors:blockblutonium>, 
 	[[<ore:blockMithril>, <ore:blockCobalt>, <ore:blockMithril>],
 	[<ic2:nuclear:7>, <ic2:nuclear:7>, <ic2:nuclear:7>], 
 	[<ore:blockCyanite>, <actuallyadditions:block_crystal_empowered:1>, <ore:blockCyanite>]]);
 # Blutonium Ingot	
-	recipes.remove(<bigreactors:ingotmetals:3>);
+	recipes.remove(<bigreactors:ingotblutonium>);
 	recipes.addShapeless("Blutonium Ingot from Block", 
-	<bigreactors:ingotmetals:3> * 9, 
-	[<bigreactors:blockmetals:3>]);
+	<bigreactors:ingotblutonium> * 9, 
+	[<bigreactors:blockblutonium>]);
 # Blutonium Ingot -> Block
 	recipes.addShaped("Blutonium Ingots to Block", 
-	<bigreactors:blockmetals:3>, 
+	<bigreactors:blockblutonium>, 
 	[[<ore:ingotBlutonium>, <ore:ingotBlutonium>, <ore:ingotBlutonium>],
 	[<ore:ingotBlutonium>, <ore:ingotBlutonium>, <ore:ingotBlutonium>], 
 	[<ore:ingotBlutonium>, <ore:ingotBlutonium>, <ore:ingotBlutonium>]]);
 
 # Ludicrite Block
-	recipes.remove(<bigreactors:blockmetals:4>);
-	mods.forestry.Carpenter.addRecipe(<bigreactors:blockmetals:4>, 
+	recipes.remove(<bigreactors:blockludicrite>);
+	mods.forestry.Carpenter.addRecipe(<bigreactors:blockludicrite>, 
 	[[<ore:gemAmethyst>, <ore:blockBlaze>, <ore:gemAmethyst>],
 	[<ore:ingotAlumite>, <ore:blockBlutonium>, <ore:ingotAlumite>], 
 	[<ore:blockEnderium>, <botania:storage:2>, <ore:blockEnderium>]], 
 	40, <liquid:liquiddna> * 1000);
 	
 	recipes.addShaped("Ludicrite Block From Ingots", 
-	<bigreactors:blockmetals:4>, 
+	<bigreactors:blockludicrite>, 
 	[[<ore:ingotLudicrite>, <ore:ingotLudicrite>, <ore:ingotLudicrite>],
 	[<ore:ingotLudicrite>, <ore:ingotLudicrite>, <ore:ingotLudicrite>], 
 	[<ore:ingotLudicrite>, <ore:ingotLudicrite>, <ore:ingotLudicrite>]]);
 
 # Yellorite Block
-	recipes.remove(<bigreactors:blockmetals>);
+	recipes.remove(<bigreactors:blockyellorium>);
 	
 # Anglesite - Crystal made of ThermalExpansion/EnvironmentalTech/Ender IO/AE2 materials
-	mods.extendedcrafting.CombinationCrafting.addRecipe(<bigreactors:minerals>, 100000000, 1000000, 
+	mods.extendedcrafting.CombinationCrafting.addRecipe(<bigreactors:mineralanglesite>, 100000000, 1000000, 
 	<appliedenergistics2:material:48>, [<thermalfoundation:material:894>,
 	<thermalfoundation:material:893>,  <thermalfoundation:material:895>, 
 	<thermalfoundation:material:865>,
@@ -120,7 +120,7 @@ print("--- loading ExtremeReactors.zs ---");
 	<enderio:item_material:17>,  <enderio:item_material:18>, <enderio:item_material:19>]);	  
 
 # Benitoite - Crystal made of Botania/AstralSorcery/BloodMagic/Thaumcraft materials
-	mods.extendedcrafting.CombinationCrafting.addRecipe(<bigreactors:minerals:1>, 100000000, 1000000, <botania:manaresource:5>, 
+	mods.extendedcrafting.CombinationCrafting.addRecipe(<bigreactors:mineralbenitoite>, 100000000, 1000000, <botania:manaresource:5>, 
 	[<botania:manaresource:9>, <botania:manaresource:1>, <botania:manaresource:7>, 
 	<botania:pylon:1>, <botania:manaresource:2>, <botania:manaresource:8>, 
 	<astralsorcery:itemcraftingcomponent:2>, #<astralsorcery:itemshiftingstar>.withTag({}), 

--- a/scripts/LootTweaker_Ice&Fire.zs
+++ b/scripts/LootTweaker_Ice&Fire.zs
@@ -24,7 +24,7 @@ print("--- loading LootTweaker_Ice&Fire.zs ---");
 	
 	val caveloot = [
 	<environmentaltech:litherite_crystal>,
-	<bigreactors:ingotmetals:3>,
+	<bigreactors:ingotblutonium>,
 	<ic2:nuclear:7>,
 	<minecraft:gold_block>,
 	<thermalfoundation:material:70>,

--- a/scripts/Mekanism.zs
+++ b/scripts/Mekanism.zs
@@ -9,7 +9,7 @@ recipes.remove(<mekanism:machineblock:2>);
 
 
 # Unifying Graphite ingots, seems the crusher was overlooked
-mods.mekanism.crusher.removeRecipe(<bigreactors::dustgraphite>, <bigreactors:ingotgraphite>);
+mods.mekanism.crusher.removeRecipe(<bigreactors:dustgraphite>, <bigreactors:ingotgraphite>);
 
 for ingot in <ore:ingotGraphite>.items {
 	mods.mekanism.crusher.addRecipe(ingot, <nuclearcraft:dust:8>);

--- a/scripts/Mekanism.zs
+++ b/scripts/Mekanism.zs
@@ -9,7 +9,7 @@ recipes.remove(<mekanism:machineblock:2>);
 
 
 # Unifying Graphite ingots, seems the crusher was overlooked
-mods.mekanism.crusher.removeRecipe(<bigreactors:dustmetals:2>, <bigreactors:ingotmetals:2>);
+mods.mekanism.crusher.removeRecipe(<bigreactors::dustgraphite>, <bigreactors:ingotgraphite>);
 
 for ingot in <ore:ingotGraphite>.items {
 	mods.mekanism.crusher.addRecipe(ingot, <nuclearcraft:dust:8>);

--- a/scripts/MiscRecipes.zs
+++ b/scripts/MiscRecipes.zs
@@ -114,11 +114,11 @@ print("--- loading MiscRecipes.zs ---");
 	recipes.addShapeless(<ic2:misc_resource:1>, [<thermalfoundation:material:135>]);
 	
 # Graphite conversion 
-	recipes.addShapeless("Graphite Conversion 1", <bigreactors:ingotmetals:2>, [<nuclearcraft:ingot:8>]);
-	recipes.addShapeless("Graphite Conversion 2", <nuclearcraft:ingot:8>, [<bigreactors:ingotmetals:2>]);
+	recipes.addShapeless("Graphite Conversion 1", <bigreactors:ingotgraphite>, [<nuclearcraft:ingot:8>]);
+	recipes.addShapeless("Graphite Conversion 2", <nuclearcraft:ingot:8>, [<bigreactors:ingotgraphite>]);
 	
-	recipes.addShapeless("Graphite Conversion 3", <bigreactors:blockmetals:2> * 2, [<nuclearcraft:ingot_block:8>, <nuclearcraft:ingot_block:8>]);
-	recipes.addShapeless("Graphite Conversion 4", <nuclearcraft:ingot_block:8> * 2, [<bigreactors:blockmetals:2>, <bigreactors:blockmetals:2>]);
+	recipes.addShapeless("Graphite Conversion 3", <bigreactors:blockgraphite> * 2, [<nuclearcraft:ingot_block:8>, <nuclearcraft:ingot_block:8>]);
+	recipes.addShapeless("Graphite Conversion 4", <nuclearcraft:ingot_block:8> * 2, [<bigreactors:blockgraphite>, <bigreactors:blockgraphite>]);
 
 # Rustic Slate
 	recipes.addShapeless("slate", 

--- a/scripts/OreDict.zs
+++ b/scripts/OreDict.zs
@@ -262,7 +262,7 @@ for item in pressurePlates {
 	<ore:blockCertusQuartz>.add(<appliedenergistics2:chiseled_quartz_block>);
 	
 # Plutonium
-	//<ore:ingotPlutonium>.remove(<bigreactors:ingotmetals:3>);
+	//<ore:ingotPlutonium>.remove(<bigreactors:ingotblutonium>);
 
 # Iridium
 	<ore:ingotIridium>.add(<ic2:misc_resource:1>);

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -97,12 +97,12 @@ print("--- loading TinkersConstruct.zs ---");
 # Removing the ability to melt coal
 val coals as IItemStack[] = [
 
-	<bigreactors:ingotmetals:2>,
-	<bigreactors:dustmetals:2>,
+	<bigreactors:ingotgraphite>,
+	<bigreactors:dustgraphite>,
 	<minecraft:coal>,
 	<minecraft:coal_block>,
 	<thermalfoundation:material:768>,
-	<bigreactors:blockmetals:2>,
+	<bigreactors:blockgraphite>,
 	<nuclearcraft:ingot_block:8>,
 	<nuclearcraft:ingot:8>,
 	<nuclearcraft:dust:8>

--- a/scripts/Tooltips.zs
+++ b/scripts/Tooltips.zs
@@ -258,16 +258,15 @@ for item in thaumcraftHintItems {
 	addDescription(<thermalexpansion:frame:148>, mil100);
 	
 # Extreme Reactors Crystals
-	<bigreactors:minerals>.displayName = "Anglesite";
-	<bigreactors:minerals:1>.displayName = "Benitoite";
+	<bigreactors:mineralanglesite>.displayName = "Anglesite";
+	<bigreactors:mineralbenitoite>.displayName = "Benitoite";
 	
-	addDescription(<bigreactors:minerals>, craftable);
-	addDescription(<bigreactors:minerals:1>, craftable);
+	addDescription(<bigreactors:mineralanglesite>, craftable);
+	addDescription(<bigreactors:mineralbenitoite>, craftable);
 
 # Uncraftable ingots
-	addDescription(<bigreactors:ingotmetals:3>,"Block of Blutonium is craftable.");
-	addDescription(<bigreactors:ingotmetals:4>,"Block of Ludicrite is craftable.");
-
+	addDescription(<bigreactors:ingotblutonium>,"Block of Blutonium is craftable.");
+	addDescription(<bigreactors:ingotludicrite>,"Block of Ludicrite is craftable.");
 # Mana Infused Ingot
 	addDescription(<thermalfoundation:material:136>,"Only obtainable through the Metallurgic Infuser, the Advanced Metallurgic Fabricator, and other planets.");
 

--- a/scripts/WirelessCraftingTerminal.zs
+++ b/scripts/WirelessCraftingTerminal.zs
@@ -16,7 +16,7 @@ print("--- loading WirelessCraftingTerminal.zs ---");
 	recipes.addShaped("Infinity Booster Card", 
 	<ae2wtlib:infinity_booster_card>, 
 	[[<appliedenergistics2:quantum_link>, <appliedenergistics2:material:47>, <appliedenergistics2:quantum_link>],
-	[<bigreactors:minerals>, <extracells:storage.component:1>, <bigreactors:minerals>], 
+	[<bigreactors:mineralanglesite>, <extracells:storage.component:1>, <bigreactors:mineralanglesite>], 
 	[<appliedenergistics2:quantum_link>, <appliedenergistics2:material:47>, <appliedenergistics2:quantum_link>]]);
 
 	print("--- WirelessCraftingTerminal.zs initialized ---");

--- a/scripts/modular_machinery/advanced_carpenter.zs
+++ b/scripts/modular_machinery/advanced_carpenter.zs
@@ -42,7 +42,7 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_pedestal", machin
 
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_ludicrite_block", machineName, 10)
 	.addEnergyPerTickInput(25000)
-	.addItemOutput(<bigreactors:blockmetals:4>)
+	.addItemOutput(<bigreactors:blockludicrite>)
 	.addItemInput(<ore:gemAmethyst>)
 	.addItemInput(<ore:blockBlutonium>)
 	.addItemInput(<ore:ingotAlumite>)


### PR DESCRIPTION
Update CraftTewaker scripts for latest Extreme Reactors version 1.12.2-0.4.5.65.

If you're going to accept this pull request, you have to update to the latest version of ZeroCore as well. You can optionally update Just Enough Reactors.

Related to this issue/suggestion:  #1646