### PR TITLE
Fix Broken Cutting Machine Recipes

### DIFF
--- a/config/advRocketry/CuttingMachine.xml
+++ b/config/advRocketry/CuttingMachine.xml
@@ -69,7 +69,7 @@
 			<itemStack>minecraft:planks 10 5</itemStack>
 		</output>
 	</Recipe>
-	<Recipe timeRequired="80" power ="125000">
+	<Recipe timeRequired="100" power ="100000">
 		<input>
 			<itemStack>advancedrocketry:itemcircuitplate</itemStack>
 		</input>
@@ -77,7 +77,7 @@
 			<itemStack>advancedrocketry:ic 4</itemStack>
 		</output>
 	</Recipe>
-	<Recipe timeRequired="100" power ="200000">
+	<Recipe timeRequired="200" power ="100000">
 		<input>
 			<itemStack>advancedrocketry:itemcircuitplate 1 1</itemStack>
 		</input>
@@ -85,7 +85,7 @@
 			<itemStack>advancedrocketry:ic 4 2</itemStack>
 		</output>
 	</Recipe>
-	<Recipe timeRequired="100" power ="200000">
+	<Recipe timeRequired="200" power ="100000">
 		<input>
 			<oreDict>bouleSilicon</oreDict>
 		</input>


### PR DESCRIPTION
The cutting machine has a maximum power buffer of 100,000 RF (as a lot of AdvRocketry machines), so any recipes that use over 100k RF/t stop functioning completely because it's impossible for it to draw more than that.

I fixed the issue by lowering the recipes that used over 100k RF/t down to 100k RF/t, but increased the process time so that it equals out to the same amount of RF either way.