### PR TITLE
🏪 Extend: New JEI categories

### DIFF
--- a/config/requious/assembly.json
+++ b/config/requious/assembly.json
@@ -1,0 +1,38 @@
+[
+  {
+    "resourceName": "infernal_furnace",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "liquid_heat_exchanger",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "neromantic_prime",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "scented_hive",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "witch_water",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "meteor",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "turbine",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "heat_exchanger",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  },
+  {
+    "resourceName": "forestry_farm",
+    "model": "requious:assembly_block","placeType": "Any","layerType": "Cutout","hasGUI": false,"extraVariants": [],"colors": [{"r": 255,"g": 255,"b": 255,"a": 255}],"hardness": 5.0,"blastResistance": 5.0,"aabb": {"x1": 0.0,"y1": 0.0,"z1": 0.0,"x2": 1.0,"y2": 1.0,"z2": 1.0}
+  }
+]

--- a/config/requious/battery.json
+++ b/config/requious/battery.json
@@ -1,0 +1,195 @@
+[
+  {
+    "capacity": 1000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "battery_copper",
+    "model": "requious:battery_small",
+    "colors": [
+      {
+        "r": 220,
+        "g": 64,
+        "b": 16,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 192,
+        "b": 64,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 2000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "battery_iron",
+    "model": "requious:battery_medium_fill0",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 192,
+        "b": 64,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 0,
+        "b": 0,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 64000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "energy_gem",
+    "model": "requious:energy_diamond",
+    "colors": [
+      {
+        "r": 255,
+        "g": 0,
+        "b": 0,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 192,
+        "b": 192,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 256000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "lapotron",
+    "model": "requious:lapotron_diamond",
+    "colors": [
+      {
+        "r": 0,
+        "g": 0,
+        "b": 255,
+        "a": 255
+      },
+      {
+        "r": 192,
+        "g": 192,
+        "b": 255,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 2048000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "lapotron_orb",
+    "model": "requious:containment_gem",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      },
+      {
+        "r": 0,
+        "g": 0,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 68000000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "quantron",
+    "model": "requious:lapotron_emerald",
+    "colors": [
+      {
+        "r": 128,
+        "g": 255,
+        "b": 0,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 255,
+        "b": 192,
+        "a": 255
+      },
+      {
+        "r": 64,
+        "g": 64,
+        "b": 64,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  },
+  {
+    "capacity": 1000000000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "positron_unit",
+    "model": "requious:containment_fill0",
+    "colors": [
+      {
+        "r": 128,
+        "g": 255,
+        "b": 192,
+        "a": 255
+      },
+      {
+        "r": 255,
+        "g": 255,
+        "b": 0,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  }
+]

--- a/config/requious/fluid_cell.json
+++ b/config/requious/fluid_cell.json
@@ -1,0 +1,22 @@
+[
+  {
+    "generateSubItems": true,
+    "capacity": 1000,
+    "minInput": 0,
+    "maxInput": 2147483647,
+    "minOutput": 0,
+    "maxOutput": 2147483647,
+    "showTooltip": true,
+    "resourceName": "cell",
+    "model": "requious:cell",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "stackSize": 64
+  }
+]

--- a/config/requious/fluid_emitter.json
+++ b/config/requious/fluid_emitter.json
@@ -1,0 +1,64 @@
+[
+  {
+    "capacity": 1000,
+    "allowLiquid": false,
+    "allowGas": false,
+    "minTemperature": 0,
+    "maxTemperature": 0,
+    "interval": 40,
+    "canEmit": false,
+    "canReceive": false,
+    "canRelay": false,
+    "resourceName": "liquid_emitter",
+    "model": "requious:fluid_emitter",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "hardness": 5.0,
+    "blastResistance": 5.0,
+    "aabb": {
+      "x1": 0.0,
+      "y1": 0.0,
+      "z1": 0.0,
+      "x2": 1.0,
+      "y2": 1.0,
+      "z2": 1.0
+    }
+  },
+  {
+    "capacity": 1000,
+    "allowLiquid": false,
+    "allowGas": false,
+    "minTemperature": 0,
+    "maxTemperature": 0,
+    "interval": 40,
+    "canEmit": false,
+    "canReceive": false,
+    "canRelay": false,
+    "resourceName": "gas_emitter",
+    "model": "requious:fluid_emitter",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "hardness": 5.0,
+    "blastResistance": 5.0,
+    "aabb": {
+      "x1": 0.0,
+      "y1": 0.0,
+      "z1": 0.0,
+      "x2": 1.0,
+      "y2": 1.0,
+      "z2": 1.0
+    }
+  }
+]

--- a/config/requious/red_emitter.json
+++ b/config/requious/red_emitter.json
@@ -1,0 +1,56 @@
+[
+  {
+    "capacity": 64,
+    "interval": 40,
+    "canEmit": false,
+    "canReceive": false,
+    "canRelay": false,
+    "resourceName": "red_emitter_basic",
+    "model": "requious:red_emitter",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "hardness": 5.0,
+    "blastResistance": 5.0,
+    "aabb": {
+      "x1": 0.0,
+      "y1": 0.0,
+      "z1": 0.0,
+      "x2": 1.0,
+      "y2": 1.0,
+      "z2": 1.0
+    }
+  },
+  {
+    "capacity": 128,
+    "interval": 20,
+    "canEmit": false,
+    "canReceive": false,
+    "canRelay": false,
+    "resourceName": "red_emitter_advanced",
+    "model": "requious:red_emitter",
+    "colors": [
+      {
+        "r": 255,
+        "g": 255,
+        "b": 255,
+        "a": 255
+      }
+    ],
+    "hardness": 5.0,
+    "blastResistance": 5.0,
+    "aabb": {
+      "x1": 0.0,
+      "y1": 0.0,
+      "z1": 0.0,
+      "x2": 1.0,
+      "y2": 1.0,
+      "z2": 1.0
+    }
+  }
+]

--- a/resources/enigmatica/lang/en_us.lang
+++ b/resources/enigmatica/lang/en_us.lang
@@ -1,0 +1,9 @@
+requious.jei.recipe.infernal_furnace=Infernal Furnace
+requious.jei.recipe.liquid_heat_exchanger=Liquid Heat Exchanger
+requious.jei.recipe.neromantic_prime=Neromantic Prime
+requious.jei.recipe.scented_hive=Scented Hive
+requious.jei.recipe.heat_exchanger=Heat Exchanger
+requious.jei.recipe.witch_water=Witch Water
+requious.jei.recipe.meteor=Meteor
+requious.jei.recipe.turbine=Turbine
+requious.jei.recipe.forestry_farm=Forestry Farm

--- a/resources/enigmatica/lang/ru_ru.lang
+++ b/resources/enigmatica/lang/ru_ru.lang
@@ -1,0 +1,9 @@
+requious.jei.recipe.infernal_furnace=Инфернальная Печь
+requious.jei.recipe.liquid_heat_exchanger=Жидкостный теплообменник
+requious.jei.recipe.neromantic_prime=Неромантик Прайм
+requious.jei.recipe.scented_hive=Ароматный улей
+requious.jei.recipe.heat_exchanger=Теплообменник
+requious.jei.recipe.witch_water=Ведьмина Вода
+requious.jei.recipe.meteor=Метеор
+requious.jei.recipe.turbine=Турбина
+requious.jei.recipe.forestry_farm=Forestry Фермы

--- a/scripts/requiousJei.zs
+++ b/scripts/requiousJei.zs
@@ -1,0 +1,370 @@
+#priority 1000
+#modloaded requious
+
+import mods.requious.Assembly;
+import mods.requious.AssemblyRecipe;
+import mods.requious.SlotVisual;
+import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemStack;
+import crafttweaker.liquid.ILiquidStack;
+import crafttweaker.item.WeightedItemStack;
+
+
+function add(ass as Assembly, chunk as IItemStack[][IIngredient[]]) {
+  for inputs, outputs in chunk {
+    val assRec = AssemblyRecipe.create(function(container) {
+      for i, output in outputs {
+        container.addItemOutput("output" ~ i, output);
+      }
+    });
+    for i, input in inputs {
+      assRec.requireItem("input"~i, input);
+    }
+    ass.addJEIRecipe(assRec);
+  }
+}
+
+function addInsOuts(ass as Assembly, inputs as int[][], outputs as int[][]) {
+  for j,way in ['input', 'output'] as string[] {
+    for i,pair in (j==0 ? inputs : outputs) {
+      ass.setJEIItemSlot(pair[0], pair[1], way ~ i);
+    }
+  }
+}
+
+function getVisGauge(u as int, w as int) as SlotVisual {
+  return SlotVisual.create(1,1).addPart("requious:textures/gui/assembly_gauges.png",u,w);
+}
+function getVisSlots(u as int, w as int) as SlotVisual {
+  return SlotVisual.create(1,1).addPart("requious:textures/gui/assembly_slots.png",u,w);
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+var 
+x = <assembly:infernal_furnace>;
+x.addJEICatalyst(<thaumcraft:infernal_furnace>);
+x.setJEIDurationSlot(1,0,"duration", SlotVisual.arrowRight());
+x.setJEIDurationSlot(2,0,"duration", getVisGauge(1,13));
+addInsOuts(x, [[0,0]], [[3,0]]);
+
+function add_infernal_furnace(input as IIngredient, out as WeightedItemStack) {
+  add(<assembly:infernal_furnace>, {[input] as IIngredient[]: [out.stack.withLore(["§d§l" ~ out.percent as int ~ "%"])]});
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:liquid_heat_exchanger>;
+x.addJEICatalyst(<ic2:te:31>);
+x.setJEIFluidSlot(0, 0, 'liquid_input');
+x.setJEIItemSlot(1, 0, 'item_in');
+x.setJEIDurationSlot(2,0,"duration", getVisGauge(5,1));
+x.setJEIFluidSlot(3, 0, 'liquid_output');
+
+for l_in, l_out in {
+  lava: 'ic2pahoehoe_lava',
+  ic2hot_coolant: 'ic2coolant',
+} as string[string] {
+  x.addJEIRecipe(AssemblyRecipe.create(function(container) {
+    container.addFluidOutput('liquid_output', game.getLiquid(l_out));
+  })
+  .requireFluid('liquid_input', game.getLiquid(l_in))
+  .requireItem("item_in", <ic2:crafting:7>)
+  );
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:neromantic_prime>;
+x.addJEICatalyst(<astralsorcery:blockbore>);
+x.addJEICatalyst(<astralsorcery:blockborehead>);
+x.addJEICatalyst(<astralsorcery:blockchalice>);
+
+static fluidOutputs as ILiquidStack[] = [
+/*Inject_js(
+config('astralsorcery/fluid_rarities.cfg').data.data
+.slice(0, 9*5)
+.map(l=>l.split(';'))
+.map(l=>[
+  parseInt(l[3]),
+  `  <fluid:${(l[0]+'>').padEnd(24)} * ${l[3]},`
+])
+.sort(([a], [b]) => b - a)
+.map(([_,l])=>l)
+.join('\n')
+)*/
+  <fluid:mana>                    * 1500,
+  <fluid:amber>                   * 800,
+  <fluid:xpjuice>                 * 500,
+  <fluid:pyrotheum>               * 200,
+  <fluid:cryotheum>               * 200,
+  <fluid:hydrofluoric_acid>       * 120,
+  <fluid:mutagen>                 * 100,
+  <fluid:vibrant_alloy>           * 40,
+  <fluid:ic2uu_matter>            * 1,
+/**/
+];
+
+for i, fluid in fluidOutputs {
+  x.setJEIFluidSlot(i % 9, (i / 9) as int, 'f'~i);
+}
+x.addJEIRecipe(AssemblyRecipe.create(function(container) {
+  for i, output in fluidOutputs {
+    container.addFluidOutput("f"~i, output);
+  }
+}));
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:scented_hive>;
+x.addJEICatalyst(<exnihilocreatio:hive:1>);
+x.setJEIDurationSlot(3,0,"duration", getVisSlots(5,1));
+addInsOuts(x, [[1,1],[1,0],[2,0],[0,0]], [[4,0]]);
+
+val worldItem as IItemStack[int] = {
+  0: <biomesoplenty:earth>.withTag({display:{Name:"§6OVERWORLD"}}),
+  1: <biomesoplenty:earth>.withTag({display:{Name:"§6THE END"}}),
+};
+
+/*Inject_js(
+JSON.parse(loadText('config/exnihilocreatio/ScentedHiveRegistry.json'))
+.map(l=>`add(x, {[worldItem[${l.dim}], ${'<exnihilocreatio:hive:1>'}, ${
+  Object.keys(l.adjacentBlocks).map(i=>`<${i}>`).join(', ')
+}] : [<${l.hive}>]});`)
+.join('\n')
+)*/
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <ore:treeLeaves>, <ore:logWood>] : [<forestry:beehives:0>]});
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <ore:flower>] : [<forestry:beehives:1>]});
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <ore:sand>] : [<forestry:beehives:2>]});
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <minecraft:log:3>, <ore:treeLeaves>] : [<forestry:beehives:3>]});
+add(x, {[worldItem[1], <exnihilocreatio:hive:1>, <minecraft:end_stone:0>] : [<forestry:beehives:4>]});
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <minecraft:ice:0>, <minecraft:snow:0>] : [<forestry:beehives:5>]});
+add(x, {[worldItem[0], <exnihilocreatio:hive:1>, <ore:dirt>] : [<forestry:beehives:6>]});
+/**/
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:witch_water>;
+x.addJEICatalyst(Bucket('witchwater'));
+x.setJEIDurationSlot(1,0,"duration", getVisGauge(1,8));
+addInsOuts(x, [[0,0]], [[2,0]]);
+add(x, {[Soul('minecraft:skeleton')] : [Soul('minecraft:wither_skeleton')]});
+add(x, {[Soul('minecraft:creeper')]  : [Soul('minecraft:creeper')]});
+add(x, {[Soul('minecraft:slime')]    : [Soul('minecraft:magma_cube')]});
+add(x, {[Soul('minecraft:spider')]   : [Soul('minecraft:cave_spider')]});
+add(x, {[Soul('minecraft:squid')]    : [Soul('minecraft:ghast')]});
+add(x, {[Soul('minecraft:villager')] : [Soul('minecraft:zombie_villager')]});
+add(x, {[Soul('minecraft:pig')]      : [Soul('minecraft:zombie_pigman')]});
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:meteor>;
+x.addJEICatalyst(<bloodmagic:ritual_diviner:1>.withTag({current_ritual: "meteor"}));
+x.setJEIDurationSlot(1,1,"duration", getVisGauge(1,8));
+x.setJEIItemSlot (0, 1, 'f0');
+x.setJEIFluidSlot(0, 0, 'f1');
+
+static meteors as string[][] = [
+/*Inject_js(
+fs.readdirSync('config/bloodmagic/meteors')
+.map(filename => JSON.parse(loadText('config/bloodmagic/meteors/' + filename)))
+.map(f=>
+  [
+  `${f.catalystStack.registryName.domain}:${f.catalystStack.registryName.path}`,
+  f.catalystStack.meta,
+  f.cost,
+  ...f.components.map(c=>c.oreName.substring(3))
+  ]
+ .map(s=>`"${s}"`).join(', ')
+).map(s=>`[${s}]`).join(',\n')
+)*/
+["minecraft:iron_block", "0", "600000", "Iron", "Copper", "Tin", "Silver", "Lead", "Gold", "Lapis", "Redstone", "Aluminum"],
+["thermalfoundation:storage", "6", "600000", "Iron", "Copper", "Tin", "Gold", "AstralStarmetal", "Draconium", "Nickel", "Osmium", "Platinum", "Rutile", "Uranium"],
+["thermalfoundation:storage", "7", "1000000", "Iron", "Gold", "Lapis", "Emerald", "Redstone", "Diamond", "Iridium", "Mithril"],
+["nuclearcraft:ingot_block", "3", "1100000", "Thorium", "Boron", "Lithium", "Magnesium"],
+["minecraft:emerald_block", "0", "1400000", "Lapis", "Diamond", "Emerald", "Coal", "Ruby", "Peridot", "Topaz", "Tanzanite", "Malachite", "Sapphire", "Amber", "Apatite", "CertusQuartz", "Cinnabar", "Prosperity", "QuartzBlack"],
+["tconstruct:metal", "1", "1700000", "Quartz", "NetherAluminum", "NetherCopper", "NetherLead", "NetherNickel", "NetherRedstone", "NetherLapis", "NetherIron", "NetherGold", "NetherEmerald", "NetherDiamond", "NetherCoal", "NetherPlatinum", "NetherSilver", "NetherTin", "NetherCertusQuartz", "NetherChargedCertusQuartz", "NetherOsmium", "NetherUranium", "Cobalt", "Ardite"]
+/**/
+];
+
+var k = 0;
+var maxRows = 0;
+for t in meteors { if(t.length > maxRows) maxRows = t.length; }
+for _y in 0 .. ((maxRows - 4) / 7 + 1) as int {
+  for _x in 2 .. 9 {
+    x.setJEIItemSlot(_x, _y, 'i'~k);
+    k += 1;
+  }
+}
+
+for i, meteor in meteors {
+  val meteorAss = AssemblyRecipe.create(function(container) {
+    for i, ore in meteor {
+      if(i<3) continue;
+      container.addItemOutput("i"~(i - 3), oreDict.get('ore' ~ ore).firstItem);
+    }
+  });
+  meteorAss.requireItem('f0', itemUtils.getItem(meteor[0], meteor[1]));
+  meteorAss.requireFluid('f1', <fluid:lifeessence> * (meteor[2] as int));
+  x.addJEIRecipe(meteorAss);
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+static turbineFuel as int[string][] = [
+/*Inject_js(
+[...
+  loadText('config/AdvGenerators/overrides/turbine.cfg')
+  .matchAll(/^\s+turbine-fuel\s*:\s*([^\s]+)\s+([^\s]+)\s+.*$/gm)
+].sort((a,b)=>a[2] - b[2])
+.map(([_, name, mj_mb])=>`  {${name.padEnd(16)}: ${mj_mb}},`)
+.join('\n')
+)*/
+  {liquidhydrogen  : 4},
+  {gasoline        : 5},
+  {canolaoil       : 10},
+  {refinedcanolaoil: 20},
+  {oil             : 25},
+  {biomass         : 30},
+  {biodiesel       : 40},
+  {crystaloil      : 40},
+  {ic2biogas       : 50},
+  {diesel          : 70},
+  {ethene          : 80},
+  {biofuel         : 90},
+  {refined_oil     : 95},
+  {rocket_fuel     : 95},
+  {syngas          : 100},
+  {refined_fuel    : 105},
+  {rocketfuel      : 110},
+  {fire_water      : 120},
+  {empoweredoil    : 120},
+/**/
+];
+
+x = <assembly:turbine>;
+x.addJEICatalyst(<advgenerators:turbine_controller>);
+x.setJEIDurationSlot(1,0,"duration", getVisGauge(0,5));
+x.setJEIFluidSlot(0, 0, 'liquid_input');
+x.setJEIEnergySlot(2, 0, 'energy_out', "rf");
+
+for map in turbineFuel {
+  for name, mj_mb in map {
+    val liq = game.getLiquid(name);
+    if(isNull(liq)) {
+      logger.logWarning('Liquid ['~name~'] not exist. Remove it from config/AdvGenerators/overrides/turbine.cfg');
+      continue;
+    }
+    x.addJEIRecipe(AssemblyRecipe.create(function(container) {
+      container.addEnergyOutput('energy_out', mj_mb, 0);
+    }).requireFluid('liquid_input', liq));
+  }
+}
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:heat_exchanger>;
+x.addJEICatalyst(<advgenerators:exchanger_controller>);
+x.setJEIFluidSlot(0, 0, 'fluid_in');
+x.setJEIItemSlot(1, 0, 'item_in');
+x.setJEIDurationSlot(2,0,"duration", getVisGauge(9,1));
+x.setJEIFluidSlot(3, 0, 'fluid_out');
+x.setJEIItemSlot(4, 0, 'item_out1');
+x.setJEIItemSlot(5, 0, 'item_out2');
+
+function showHeat(heat as int) as IItemStack {
+  return <ic2:heat_exchanger>.withTag({advDmg: (2500 - heat), display:{Name:"§e"~heat~" Heat"}});
+}
+
+function addHeatExch(fluid_in as ILiquidStack, heat_in as int, fluid_out as ILiquidStack, item_out1 as IItemStack, heat_out as int) {
+  val r = AssemblyRecipe.create(function(container) {
+    if(!isNull(fluid_out)) container.addFluidOutput('fluid_out', fluid_out);
+    if(!isNull(item_out1)) container.addItemOutput('item_out1', item_out1);
+    if(heat_out>0) container.addItemOutput('item_out2', showHeat(heat_out));
+  })
+  .requireFluid('fluid_in', fluid_in);
+  if(heat_in>0) r.requireItem('item_in', showHeat(heat_in));
+  <assembly:heat_exchanger>.addJEIRecipe(r);
+}
+
+/*Inject_js(
+(()=>{
+const cfg = [...
+  loadText('config/AdvGenerators/overrides/exchanger.cfg')
+  .matchAll(/^\s*exchanger\s*:\s*(.*)$/gm)
+].map(([,m])=>m.trim())
+const bl = (id)=>{const s=id.split(':'); return s.length>=2?id.replace(/@(\d+)/,':$1'):'minecraft:'+s[0]}
+const B = (block,amount)=>`<${bl(block)}>${parseFloat(amount)>1?' * ' + amount : ''}`
+const H = (h)=>Math.round(h)
+return cfg
+.map(g=>g.match(
+  /fluid:(\w+) (\d+) mB(?: \+ (\d+) HU)? =>(?: fluid:(\w+) (\d+) ?mB)?(?: [BI]:(\w+(?::\w+)?(?:@\d+)?) (\d+\.\d+))?(?: \+ (\d+) HU)?/
+)?.slice(1))
+.filter(m=>m)
+.map(([
+  fluid_in, fluid_in_amount, heat_in, 
+  fluid_out, fluid_out_amount, item_out, item_out_amount, heat_out
+])=>
+  `addHeatExch(${B('fluid:'+fluid_in, fluid_in_amount)}, ` +
+  `${H(heat_in ?? 0)}, ` +
+  `${fluid_out ? B('fluid:'+fluid_out, fluid_out_amount) : 'null'}, ` +
+  `${item_out ? B(item_out, item_out_amount) : 'null'}, ` +
+  `${H(heat_out ?? 0)});`
+)
+})()
+)*/
+addHeatExch(<fluid:lava>, 0, null, <minecraft:obsidian>, 30);
+addHeatExch(<fluid:ic2pahoehoe_lava>, 0, null, <advancedrocketry:basalt>, 40);
+addHeatExch(<fluid:pyrotheum>, 0, null, <chisel:basalt2:7>, 60);
+addHeatExch(<fluid:fire_water>, 0, null, <botania:blazeblock>, 200);
+addHeatExch(<fluid:enrichedlava>, 0, null, <draconicevolution:infused_obsidian>, 500);
+addHeatExch(<fluid:water> * 5, 3, <fluid:steam> * 15, null, 0);
+addHeatExch(<fluid:distwater>, 200, <fluid:steam> * 300, null, 0);
+addHeatExch(<fluid:ic2hot_water>, 120, <fluid:steam> * 300, null, 0);
+addHeatExch(<fluid:ic2distilled_water>, 160, <fluid:steam> * 400, null, 0);
+addHeatExch(<fluid:ic2hot_coolant>, 0, <fluid:ic2coolant>, null, 40);
+/**/
+
+
+// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
+x = <assembly:forestry_farm>;
+x.setJEIItemSlot(0, 0, 'item_in');
+x.setJEIDurationSlot(1,0,"duration", getVisSlots(11,1));
+for i in 0 .. 11 {
+  x.addJEICatalyst(<forestry:ffarm:3>.withTag({FarmBlock: i}));
+}
+
+static fertilizers as IItemStack[] = [
+/*Inject_js(
+(()=>{
+let t = config('forestry/farm.cfg').fertilizers.items
+  .map(l=>l.split(';'))
+let max =       Math.max(...t.map(l=>l[1]))
+let qnt = max / Math.min(...t.map(l=>l[1])) + 1
+return t
+  .sort((a,b)=>b[1]-a[1])
+  .map(([id,value])=>`  <${id}> * ${
+    Math.min(64, Math.max(1, qnt * max / value | 0))
+  },`)
+  .join('\n')
+})()
+)*/
+  <thermalfoundation:fertilizer:2> * 7,
+  <mysticalagriculture:mystical_fertilizer> * 8,
+  <mysticalagriculture:fertilized_essence> * 13,
+  <thermalfoundation:fertilizer:1> * 14,
+  <industrialforegoing:fertilizer> * 15,
+  <botania:fertilizer> * 17,
+  <forestry:fertilizer_compound> * 21,
+  <actuallyadditions:item_fertilizer> * 42,
+  <ic2:crop_res:2> * 42,
+  <thermalfoundation:fertilizer> * 42,
+/**/
+];
+
+for input in fertilizers {
+  x.addJEIRecipe(AssemblyRecipe.create(function(container) {})
+    .requireItem("item_in", input)
+  );
+}


### PR DESCRIPTION
**Requious Fracto** is mod that adding ability to build own machines for modpack makers.  
But also, it can add custom JEI Categories with CraftTweaker.

This could help every player, because some critical crafts just hidden.  
Also this would allow to remove some tooltips / tips and move them to JEI.  
This could make life much easier. In my experience, if craft didnt exist in JEI, it didnt exists at all.

This PR contains a list of several new JEI categories.

Note: Pic examples could content items and recipes not actually exist in `E2E`
(screenshots made from `E2E-Extended` addon). This would be refined if idea would be approved.

- **Turbine**: List of all fuels ![](https://git.io/JcNCa "Gas Turbine controller") could use.  
  <img src="https://i.imgur.com/0H5SziZ.png" width=300>
- **Liquid Heat Exchanger**: help to find how to craft ![](https://git.io/JLhhG "Pahoehoe Lava").  
  <img src="https://i.imgur.com/QEkB9dz.png" width=300>
- **Infernal Furnace**: would help to find custom nugget output.  
  <img src="https://i.imgur.com/gl9hYHy.png" width=300>
- **Neromantic Prime**: Show list of all liquids this *Astral Sorcery* ritual can provide.  
  <img src="https://i.imgur.com/s8iOUsA.png" width=300>
- **Scented Hive**: If "Bee Rework" PR would be accepted, could show what blocks required to spawn hives.  
  <img src="https://i.imgur.com/lOZsT7G.png" width=300>
- **Heat Exchanger**: Shows input and output items+liquids.  
  <img src="https://i.imgur.com/IVcFzs7.png" width=300>
- **Witch Water**: View that some entities could turn into another.  
  <img src="https://i.imgur.com/Q1LzYJP.png" width=300>
- **Meteor**: Shows *Blood Magic* meteor ores.  
  <img src="https://i.imgur.com/Iff1JLm.png" width=300>
- **Forestry Farm**: shows list of fertilizers and their efficiency.  
  <img src="https://i.imgur.com/xwAZaRb.png" width=300>
