### PR TITLE
MD biomes ores updates

### DIFF
--- a/config/laser_drill_ores/biomesoplenty_ores.json
+++ b/config/laser_drill_ores/biomesoplenty_ores.json
@@ -1,18 +1,5 @@
 [
   {
-    "item" : "biomesoplenty:biome_block:0",
-    "color" : 0,
-    "rarity" : [
-      {
-        "whitelist": "",
-        "blacklist": "minecraft:hell, minecraft:sky",
-        "depth_min": 0,
-        "depth_max": 255,
-        "weight": 1
-      }
-    ]
-  },
-  {
     "item" : "biomesoplenty:gem_ore:0",
     "color" : 2,
     "rarity" : [

--- a/scripts/BiomesOPlenty.zs
+++ b/scripts/BiomesOPlenty.zs
@@ -2,6 +2,10 @@ import crafttweaker.item.IItemStack as IItemStack;
 import mods.jei.JEI.removeAndHide as rh;
 #modloaded biomesoplenty
 
+# Remove biome essence ore
+	rh(<biomesoplenty:biome_block>);
+	rh(<biomesoplenty:biome_essence>);
+
 # Poison bucket recipe fix (bucket could be duped)
 	recipes.remove(<forge:bucketfilled>.withTag({FluidName: "poison", Amount: 1000}));
 	recipes.addShapeless("biomesoplenty_forge_bucketfilled_poison_dupefix", <forge:bucketfilled>.withTag({FluidName: "poison", Amount: 1000}), 


### PR DESCRIPTION
I have removed biome essence ore from being given by the IF laser, and removed it from JEI via the rh function. The only use for the resulting drop was crafting BOP saplings.